### PR TITLE
Allow rotating Y axis labels and fix bug when that is the case

### DIFF
--- a/SwiftCharts/Axis/ChartAxisLabel.swift
+++ b/SwiftCharts/Axis/ChartAxisLabel.swift
@@ -20,7 +20,7 @@ public class ChartAxisLabel {
         if self.settings.rotation == 0 {
             return size
         } else {
-            return ChartUtils.boundingRectAfterRotatingRect(CGRectMake(0, 0, size.width, size.height), radians: self.settings.rotation).size
+            return ChartUtils.boundingRectAfterRotatingRect(CGRectMake(0, 0, size.width, size.height), radians: self.settings.rotation * CGFloat(M_PI) / 180.0).size
         }
     }()
     

--- a/SwiftCharts/Axis/ChartAxisLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisLayerDefault.swift
@@ -88,7 +88,13 @@ class ChartAxisLayerDefault: ChartAxisLayer {
             sum + self.labelMaybeSize(label).height
         }
     }()
-    
+
+    lazy var axisTitleLabelsWidth: CGFloat = {
+        return self.axisTitleLabels.reduce(0) {sum, label in
+            sum + self.labelMaybeSize(label).width
+        }
+    }()
+
     var width: CGFloat {
         fatalError("override")
     }

--- a/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
@@ -25,7 +25,7 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
     }
     
     override var width: CGFloat {
-        return self.labelsMaxWidth + self.settings.axisStrokeWidth + self.settings.labelsToAxisSpacingY + self.settings.axisTitleLabelsToLabelsSpacing + self.axisTitleLabelsHeight
+        return self.labelsMaxWidth + self.settings.axisStrokeWidth + self.settings.labelsToAxisSpacingY + self.settings.axisTitleLabelsToLabelsSpacing + self.axisTitleLabelsWidth
     }
     
     override var length: CGFloat {
@@ -42,7 +42,7 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
             let axisLabel = firstTitleLabel
             let labelSize = ChartUtils.textSize(axisLabel.text, font: axisLabel.settings.font)
             let settings = axisLabel.settings
-            let newSettings = ChartLabelSettings(font: settings.font, fontColor: settings.fontColor, rotation: -90, rotationKeep: settings.rotationKeep)
+            let newSettings = ChartLabelSettings(font: settings.font, fontColor: settings.fontColor, rotation: settings.rotation, rotationKeep: settings.rotationKeep)
             let axisLabelDrawer = ChartLabelDrawer(text: axisLabel.text, screenLoc: CGPointMake(
                 self.p1.x + offset,
                 self.p2.y + ((self.p1.y - self.p2.y) / 2) - (labelSize.height / 2)), settings: newSettings)

--- a/SwiftCharts/Axis/ChartAxisYLowLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYLowLayerDefault.swift
@@ -21,7 +21,7 @@ class ChartAxisYLowLayerDefault: ChartAxisYLayerDefault {
     }
     
     private lazy var labelsOffset: CGFloat = {
-        return self.axisTitleLabelsHeight + self.settings.axisTitleLabelsToLabelsSpacing
+        return self.axisTitleLabelsWidth + self.settings.axisTitleLabelsToLabelsSpacing
     }()
     
     private lazy var lineOffset: CGFloat = {

--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -24,6 +24,12 @@ public class ChartLabelSettings {
     }
 }
 
+public class ChartAxisYLabelSettings: ChartLabelSettings {
+    override public init(font: UIFont = UIFont.systemFontOfSize(14), fontColor: UIColor = UIColor.blackColor(), rotation: CGFloat = -90, rotationKeep: ChartLabelDrawerRotationKeep = .Center, shiftXOnRotation: Bool = true) {
+        super.init(font: font, fontColor: fontColor, rotation: rotation, rotationKeep: rotationKeep, shiftXOnRotation: shiftXOnRotation)
+    }
+}
+
 // coordinate of original label which will be preserved after the rotation
 public enum ChartLabelDrawerRotationKeep {
     case Center, Top, Bottom


### PR DESCRIPTION
This change came from a use case where we had Y axis title labels on the left and right that corresponded with two different data sets shown at the same time. We wanted both labels' baselines to be on the inside (facing the chart) and so we needed the right-side title label to be rotated 90 degrees instead of the standard -90.

This change creates a label settings subclass for the Y axis that has the same default values as before (particularly the -90 degree rotation) but allows changing the rotation value. When the value is rotated, the Y layer now uses the correct dimension of the axis title label in order to calculate the width. The label also correctly calculates its rotated bounds (previously it treated degrees as radians).