### PR TITLE
Update Chart.swift

### DIFF
--- a/SwiftCharts/Chart.swift
+++ b/SwiftCharts/Chart.swift
@@ -85,7 +85,7 @@ public class ChartBaseView: UIView {
         self.sharedInit()
     }
 
-    required public init(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.sharedInit()
     }


### PR DESCRIPTION
Changing Init to Init? on line 88 to address "A non-failable initializer cannot chain to failable initializer 'init(coder:)' written with 'init?'" requirement starting in Xcode Beta 3.