### PR TITLE
Prefer Double over CGFloat for scalar values

### DIFF
--- a/Examples/Examples/Examples/CandleStickInteractiveExample.swift
+++ b/Examples/Examples/Examples/CandleStickInteractiveExample.swift
@@ -102,9 +102,9 @@ class CandleStickInteractiveExample: UIViewController {
             let x = screenLoc.x
             
             let highScreenY = screenLoc.y
-            let lowScreenY = layer.modelLocToScreenLoc(x: x, y: chartPoint.low).y
-            let openScreenY = layer.modelLocToScreenLoc(x: x, y: chartPoint.open).y
-            let closeScreenY = layer.modelLocToScreenLoc(x: x, y: chartPoint.close).y
+            let lowScreenY = layer.modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.low)).y
+            let openScreenY = layer.modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.open)).y
+            let closeScreenY = layer.modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.close)).y
             
             let (rectTop, rectBottom, fillColor) = closeScreenY < openScreenY ? (closeScreenY, openScreenY, UIColor.whiteColor()) : (openScreenY, closeScreenY, UIColor.blackColor())
             let v = ChartCandleStickView(lineX: screenLoc.x, width: Env.iPad ? 10 : 5, top: highScreenY, bottom: lowScreenY, innerRectTop: rectTop, innerRectBottom: rectBottom, fillColor: fillColor, strokeWidth: Env.iPad ? 1 : 0.5)

--- a/Examples/Examples/Examples/GroupedAndStackedBarsExample.swift
+++ b/Examples/Examples/Examples/GroupedAndStackedBarsExample.swift
@@ -17,7 +17,7 @@ class GroupedAndStackedBarsExample: UIViewController {
     private func barsChart(horizontal horizontal: Bool) -> Chart {
         let labelSettings = ChartLabelSettings(font: ExamplesDefaults.labelFont)
         
-        let groupsData: [(title: String, bars: [(start: CGFloat, quantities: [CGFloat])])] = [
+        let groupsData: [(title: String, bars: [(start: CGFloat, quantities: [Double])])] = [
             ("A", [
                 (0,
                     [-20, -5, -10]
@@ -65,7 +65,6 @@ class GroupedAndStackedBarsExample: UIViewController {
         ]
         
         let frameColors = [UIColor.redColor().colorWithAlphaComponent(0.6), UIColor.blueColor().colorWithAlphaComponent(0.6), UIColor.greenColor().colorWithAlphaComponent(0.6)]
-        
         let groups: [ChartPointsBarGroup<ChartStackedBarModel>] = Array(groupsData.enumerate()).map {index, entry in
             let constant = ChartAxisValueFloat(CGFloat(index))
             let bars: [ChartStackedBarModel] = Array(entry.bars.enumerate()).map {index, bars in

--- a/Examples/Examples/Examples/MultipleLabelsExample.swift
+++ b/Examples/Examples/Examples/MultipleLabelsExample.swift
@@ -59,12 +59,12 @@ class MultipleLabelsExample: UIViewController {
 private class MyMultiLabelAxisValue: ChartAxisValue {
     
     private let myVal: Int
-    private let derivedVal: CGFloat
+    private let derivedVal: Double
     
     init(myVal: Int) {
         self.myVal = myVal
-        self.derivedVal = CGFloat(myVal) / 5.0
-        super.init(scalar: CGFloat(myVal))
+        self.derivedVal = Double(myVal) / 5.0
+        super.init(scalar: Double(myVal))
     }
     
     override var labels:[ChartAxisLabel] {

--- a/SwiftCharts/Axis/ChartAxisLayer.swift
+++ b/SwiftCharts/Axis/ChartAxisLayer.swift
@@ -23,5 +23,5 @@ public protocol ChartAxisLayer: ChartLayer {
     var lineP1: CGPoint {get}
     var lineP2: CGPoint {get}
     
-    func screenLocForScalar(scalar: CGFloat) -> CGFloat
+    func screenLocForScalar(scalar: Double) -> CGFloat
 }

--- a/SwiftCharts/Axis/ChartAxisLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisLayerDefault.swift
@@ -77,7 +77,7 @@ class ChartAxisLayerDefault: ChartAxisLayer {
     
     var modelLength: CGFloat {
         if let first = self.axisValues.first, let last = self.axisValues.last {
-            return last.scalar - first.scalar
+            return CGFloat(last.scalar - first.scalar)
         } else {
             return 0
         }
@@ -168,7 +168,7 @@ class ChartAxisLayerDefault: ChartAxisLayer {
         return labelMaybe?.textSize ?? CGSizeZero
     }
     
-    final func screenLocForScalar(scalar: CGFloat) -> CGFloat {
+    final func screenLocForScalar(scalar: Double) -> CGFloat {
         if let firstScalar = self.axisValues.first?.scalar {
             return self.screenLocForScalar(scalar, firstAxisScalar: firstScalar)
         } else {
@@ -177,11 +177,11 @@ class ChartAxisLayerDefault: ChartAxisLayer {
         }
     }
 
-    func innerScreenLocForScalar(scalar: CGFloat, firstAxisScalar: CGFloat) -> CGFloat {
-        return self.length * (scalar - firstAxisScalar) / self.modelLength
+    func innerScreenLocForScalar(scalar: Double, firstAxisScalar: Double) -> CGFloat {
+        return self.length * CGFloat(scalar - firstAxisScalar) / self.modelLength
     }
     
-    func screenLocForScalar(scalar: CGFloat, firstAxisScalar: CGFloat) -> CGFloat {
+    func screenLocForScalar(scalar: Double, firstAxisScalar: Double) -> CGFloat {
         fatalError("must override")
     }
     

--- a/SwiftCharts/Axis/ChartAxisValuesGenerator.swift
+++ b/SwiftCharts/Axis/ChartAxisValuesGenerator.swift
@@ -13,15 +13,15 @@ public typealias ChartAxisValueGenerator = (CGFloat) -> ChartAxisValue
 // Dynamic axis values generation
 public struct ChartAxisValuesGenerator {
     
-    public static func generateXAxisValuesWithChartPoints(chartPoints: [ChartPoint], minSegmentCount: CGFloat, maxSegmentCount: CGFloat, multiple: CGFloat = 10, axisValueGenerator: ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue] {
+    public static func generateXAxisValuesWithChartPoints(chartPoints: [ChartPoint], minSegmentCount: Double, maxSegmentCount: Double, multiple: Double = 10, axisValueGenerator: ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue] {
         return self.generateAxisValuesWithChartPoints(chartPoints, minSegmentCount: minSegmentCount, maxSegmentCount: maxSegmentCount, multiple: multiple, axisValueGenerator: axisValueGenerator, addPaddingSegmentIfEdge: addPaddingSegmentIfEdge, axisPicker: {$0.x})
     }
     
-    public static func generateYAxisValuesWithChartPoints(chartPoints: [ChartPoint], minSegmentCount: CGFloat, maxSegmentCount: CGFloat, multiple: CGFloat = 10, axisValueGenerator: ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue] {
+    public static func generateYAxisValuesWithChartPoints(chartPoints: [ChartPoint], minSegmentCount: Double, maxSegmentCount: Double, multiple: Double = 10, axisValueGenerator: ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue] {
         return self.generateAxisValuesWithChartPoints(chartPoints, minSegmentCount: minSegmentCount, maxSegmentCount: maxSegmentCount, multiple: multiple, axisValueGenerator: axisValueGenerator, addPaddingSegmentIfEdge: addPaddingSegmentIfEdge, axisPicker: {$0.y})
     }
     
-    private static func generateAxisValuesWithChartPoints(chartPoints: [ChartPoint], minSegmentCount: CGFloat, maxSegmentCount: CGFloat, multiple: CGFloat = 10, axisValueGenerator: ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool, axisPicker: (ChartPoint) -> ChartAxisValue) -> [ChartAxisValue] {
+    private static func generateAxisValuesWithChartPoints(chartPoints: [ChartPoint], minSegmentCount: Double, maxSegmentCount: Double, multiple: Double = 10, axisValueGenerator: ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool, axisPicker: (ChartPoint) -> ChartAxisValue) -> [ChartAxisValue] {
         
         let sortedChartPoints = chartPoints.sort {(obj1, obj2) in
             return axisPicker(obj1).scalar < axisPicker(obj2).scalar
@@ -36,7 +36,7 @@ public struct ChartAxisValuesGenerator {
         }
     }
     
-    private static func generateAxisValuesWithChartPoints(first: CGFloat, last: CGFloat, minSegmentCount: CGFloat, maxSegmentCount: CGFloat, multiple: CGFloat, axisValueGenerator:ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue] {
+    private static func generateAxisValuesWithChartPoints(first: Double, last: Double, minSegmentCount: Double, maxSegmentCount: Double, multiple: Double, axisValueGenerator:ChartAxisValueGenerator, addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue] {
         
         if last < first {
             fatalError("Invalid range generating axis values")
@@ -70,8 +70,8 @@ public struct ChartAxisValuesGenerator {
         
         let offset = firstValue
         return (0...Int(segmentCount)).map {segment in
-            let scalar = offset + (CGFloat(segment) * segmentSize)
-            return axisValueGenerator(scalar)
+            let scalar = offset + (Double(segment) * segmentSize)
+            return axisValueGenerator(CGFloat(scalar))
         }
     }
     

--- a/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
@@ -66,7 +66,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
     }
     
     
-    override func screenLocForScalar(scalar: CGFloat, firstAxisScalar: CGFloat) -> CGFloat {
+    override func screenLocForScalar(scalar: Double, firstAxisScalar: Double) -> CGFloat {
         return self.p1.x + self.innerScreenLocForScalar(scalar, firstAxisScalar: firstAxisScalar)
     }
     

--- a/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
@@ -55,7 +55,7 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
     }
 
     
-    override func screenLocForScalar(scalar: CGFloat, firstAxisScalar: CGFloat) -> CGFloat {
+    override func screenLocForScalar(scalar: Double, firstAxisScalar: Double) -> CGFloat {
         return self.p1.y - self.innerScreenLocForScalar(scalar, firstAxisScalar: firstAxisScalar)
     }
     

--- a/SwiftCharts/AxisValues/ChartAxisValue.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValue.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class ChartAxisValue: Equatable {
 
-    public let scalar: CGFloat
+    public let scalar: Double
    
     public var text: String {
         return "\(self.scalar)"
@@ -28,7 +28,7 @@ public class ChartAxisValue: Equatable {
         }
     }
   
-    public init(scalar: CGFloat) {
+    public init(scalar: Double) {
         self.scalar = scalar
     }
     
@@ -36,7 +36,7 @@ public class ChartAxisValue: Equatable {
         return self.copy(self.scalar)
     }
     
-    public func copy(scalar: CGFloat) -> ChartAxisValue {
+    public func copy(scalar: Double) -> ChartAxisValue {
         return ChartAxisValue(scalar: self.scalar)
     }
 }

--- a/SwiftCharts/AxisValues/ChartAxisValueDate.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDate.swift
@@ -29,12 +29,12 @@ public class ChartAxisValueDate: ChartAxisValue {
         return [axisLabel]
     }
     
-    public class func dateFromScalar(scalar: CGFloat) -> NSDate {
+    public class func dateFromScalar(scalar: Double) -> NSDate {
         return NSDate(timeIntervalSince1970: NSTimeInterval(scalar))
     }
     
-    public class func scalarFromDate(date: NSDate) -> CGFloat {
-        return CGFloat(date.timeIntervalSince1970)
+    public class func scalarFromDate(date: NSDate) -> Double {
+        return Double(date.timeIntervalSince1970)
     }
 }
 

--- a/SwiftCharts/AxisValues/ChartAxisValueFloat.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueFloat.swift
@@ -14,7 +14,7 @@ public class ChartAxisValueFloat: ChartAxisValue {
     let labelSettings: ChartLabelSettings
 
     public var float: CGFloat {
-        return self.scalar
+        return CGFloat(self.scalar)
     }
   
     override public var text: String {
@@ -24,7 +24,7 @@ public class ChartAxisValueFloat: ChartAxisValue {
     public init(_ float: CGFloat, formatter: NSNumberFormatter = ChartAxisValueFloat.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.formatter = formatter
         self.labelSettings = labelSettings
-        super.init(scalar: float)
+        super.init(scalar: Double(float))
     }
    
     override public var labels: [ChartAxisLabel] {
@@ -33,8 +33,8 @@ public class ChartAxisValueFloat: ChartAxisValue {
     }
     
     
-    override public func copy(scalar: CGFloat) -> ChartAxisValueFloat {
-        return ChartAxisValueFloat(scalar, formatter: self.formatter, labelSettings: self.labelSettings)
+    override public func copy(scalar: Double) -> ChartAxisValueFloat {
+        return ChartAxisValueFloat(CGFloat(scalar), formatter: self.formatter, labelSettings: self.labelSettings)
     }
     
     static var defaultFormatter: NSNumberFormatter = {

--- a/SwiftCharts/AxisValues/ChartAxisValueFloatScreenLoc.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueFloatScreenLoc.swift
@@ -13,7 +13,7 @@ public class ChartAxisValueFloatScreenLoc: ChartAxisValueFloat {
     private let actualFloat: CGFloat
     
     var screenLocFloat: CGFloat {
-        return self.scalar
+        return CGFloat(self.scalar)
     }
     
     override public var text: String {

--- a/SwiftCharts/AxisValues/ChartAxisValueInt.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueInt.swift
@@ -20,7 +20,7 @@ public class ChartAxisValueInt: ChartAxisValue {
     public init(_ int: Int, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.int = int
         self.labelSettings = labelSettings
-        super.init(scalar: CGFloat(int))
+        super.init(scalar: Double(int))
     }
     
     override public var labels:[ChartAxisLabel] {
@@ -28,7 +28,7 @@ public class ChartAxisValueInt: ChartAxisValue {
         return [axisLabel]
     }
     
-    override public func copy(scalar: CGFloat) -> ChartAxisValueInt {
+    override public func copy(scalar: Double) -> ChartAxisValueInt {
         return ChartAxisValueInt(self.int, labelSettings: self.labelSettings)
     }
 }

--- a/SwiftCharts/AxisValues/ChartAxisValueString.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueString.swift
@@ -16,7 +16,7 @@ public class ChartAxisValueString: ChartAxisValue {
     public init(_ string: String = "", order: Int, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.string = string
         self.labelSettings = labelSettings
-        super.init(scalar: CGFloat(order))
+        super.init(scalar: Double(order))
     }
     
     override public var labels: [ChartAxisLabel] {

--- a/SwiftCharts/Layers/ChartCandleStickLayer.swift
+++ b/SwiftCharts/Layers/ChartCandleStickLayer.swift
@@ -26,11 +26,11 @@ public class ChartCandleStickLayer<T: ChartPointCandleStick>: ChartPointsLayer<T
             let chartPoint = model.chartPoint
             
             let x = model.screenLoc.x
-            
-            let highScreenY = self.modelLocToScreenLoc(x: x, y: chartPoint.high).y
-            let lowScreenY = self.modelLocToScreenLoc(x: x, y: chartPoint.low).y
-            let openScreenY = self.modelLocToScreenLoc(x: x, y: chartPoint.open).y
-            let closeScreenY = self.modelLocToScreenLoc(x: x, y: chartPoint.close).y
+
+            let highScreenY = self.modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.high)).y
+            let lowScreenY = self.modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.low)).y
+            let openScreenY = self.modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.open)).y
+            let closeScreenY = self.modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.close)).y
             
             let (rectTop, rectBottom, fillColor) = closeScreenY < openScreenY ? (closeScreenY, openScreenY, UIColor.whiteColor()) : (openScreenY, closeScreenY, UIColor.blackColor())
             return CandleStickScreenItem(x: x, lineTop: highScreenY, lineBottom: lowScreenY, rectTop: rectTop, rectBottom: rectBottom, width: self.itemWidth, fillColor: fillColor)

--- a/SwiftCharts/Layers/ChartPointsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLayer.swift
@@ -58,7 +58,7 @@ public class ChartPointsLayer<T: ChartPoint>: ChartCoordsSpaceLayer {
         return self.modelLocToScreenLoc(x: chartPoint.x.scalar, y: chartPoint.y.scalar)
     }
     
-    public func modelLocToScreenLoc(x x: CGFloat, y: CGFloat) -> CGPoint {
+    public func modelLocToScreenLoc(x x: Double, y: Double) -> CGPoint {
         return CGPointMake(
             self.xAxis.screenLocForScalar(x),
             self.yAxis.screenLocForScalar(y))

--- a/SwiftCharts/Layers/ChartPointsLineTrackerLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLineTrackerLayer.swift
@@ -201,16 +201,16 @@ public class ChartPointsLineTrackerLayer<T: ChartPoint>: ChartPointsLayer<T> {
                     // calculate x scalar
                     let pxXDiff = secondModel.screenLoc.x - firstModel.screenLoc.x
                     let scalarXDiff = p2.x.scalar - p1.x.scalar
-                    let factorX = scalarXDiff / pxXDiff
+                    let factorX = CGFloat(scalarXDiff) / pxXDiff
                     let currentXPx = intersection.x - firstModel.screenLoc.x
-                    let currentXScalar = currentXPx * factorX + p1.x.scalar
+                    let currentXScalar = Double(currentXPx * factorX) + p1.x.scalar
 
                     // calculate y scalar
                     let pxYDiff = fabs(secondModel.screenLoc.y - firstModel.screenLoc.y);
                     let scalarYDiff = p2.y.scalar - p1.y.scalar;
-                    let factorY = scalarYDiff / pxYDiff
+                    let factorY = CGFloat(scalarYDiff) / pxYDiff
                     let currentYPx = fabs(intersection.y - firstModel.screenLoc.y)
-                    let currentYScalar = currentYPx * factorY + p1.y.scalar
+                    let currentYScalar = Double(currentYPx * factorY) + p1.y.scalar
                     
                     let x = firstModel.chartPoint.x.copy(currentXScalar)
                     let y = secondModel.chartPoint.y.copy(currentYScalar)

--- a/SwiftCharts/Layers/ChartStackedBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartStackedBarsLayer.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public typealias ChartStackedBarItemModel = (quantity: CGFloat, bgColor: UIColor)
+public typealias ChartStackedBarItemModel = (quantity: Double, bgColor: UIColor)
 
 public class ChartStackedBarModel: ChartBarModel {
 
@@ -25,7 +25,7 @@ public class ChartStackedBarModel: ChartBarModel {
         super.init(constant: constant, axisValue1: start, axisValue2: axisValue2)
     }
     
-    lazy var totalQuantity: CGFloat = {
+    lazy var totalQuantity: Double = {
         return self.items.reduce(0) {total, item in
             total + item.quantity
         }
@@ -35,7 +35,7 @@ public class ChartStackedBarModel: ChartBarModel {
 
 class ChartStackedBarsViewGenerator<T: ChartStackedBarModel>: ChartBarsViewGenerator<T> {
     
-    private typealias FrameBuilder = (barModel: ChartStackedBarModel, item: ChartStackedBarItemModel, currentTotalQuantity: CGFloat) -> (frame: ChartPointViewBarStackedFrame, length: CGFloat)
+    private typealias FrameBuilder = (barModel: ChartStackedBarModel, item: ChartStackedBarItemModel, currentTotalQuantity: Double) -> (frame: ChartPointViewBarStackedFrame, length: CGFloat)
     
     override init(horizontal: Bool, xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, barWidth barWidthMaybe: CGFloat?, barSpacing barSpacingMaybe: CGFloat?) {
         super.init(horizontal: horizontal, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: chartInnerFrame, barWidth: barWidthMaybe, barSpacing: barSpacingMaybe)
@@ -78,7 +78,7 @@ class ChartStackedBarsViewGenerator<T: ChartStackedBarModel>: ChartBarsViewGener
             }
         }()
         
-        let stackFrames = barModel.items.reduce((currentTotalQuantity: CGFloat(0), currentTotalLength: CGFloat(0), frames: Array<ChartPointViewBarStackedFrame>())) {tuple, item in
+        let stackFrames = barModel.items.reduce((currentTotalQuantity: Double(0), currentTotalLength: CGFloat(0), frames: Array<ChartPointViewBarStackedFrame>())) {tuple, item in
             let frameWithLength = frameBuilder(barModel: barModel, item: item, currentTotalQuantity: tuple.currentTotalQuantity)
             return (currentTotalQuantity: tuple.currentTotalQuantity + item.quantity, currentTotalLength: tuple.currentTotalLength + frameWithLength.length, frames: tuple.frames + [frameWithLength.frame])
         }


### PR DESCRIPTION
I don't expect this pull request to get merged in it's current state, as I'm not sure if more/less conversions need to be made (e.g. ChartAxisValueFloat and ChartPoint). But I wanted to open this pull request to start a discussion about moving from CGFloat to Double where possible.

The impetus for this refactoring is that I was creating a line chart with dates at 1 minute intervals on the x-axis. Due to rounding errors when storing time intervals since 1970 in CGFloat, every 2-3 values were getting the same scalar value at draw time. Changing to Double solved this due to the extra precision.

Also, @i-schuetz: Awesome library! Thanks for all your hard work, and I hope I can contribute to this sweet project.