### PR TITLE
Remove labelMaybeSize function

### DIFF
--- a/SwiftCharts/Axis/ChartAxisLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisLayerDefault.swift
@@ -84,14 +84,14 @@ class ChartAxisLayerDefault: ChartAxisLayer {
     }
     
     lazy var axisTitleLabelsHeight: CGFloat = {
-        return self.axisTitleLabels.reduce(0) {sum, label in
-            sum + self.labelMaybeSize(label).height
+        return self.axisTitleLabels.reduce(0) { sum, label in
+            sum + label.textSize.height
         }
     }()
 
     lazy var axisTitleLabelsWidth: CGFloat = {
-        return self.axisTitleLabels.reduce(0) {sum, label in
-            sum + self.labelMaybeSize(label).width
+        return self.axisTitleLabels.reduce(0) { sum, label in
+            sum + label.textSize.width
         }
     }()
 
@@ -164,10 +164,6 @@ class ChartAxisLayerDefault: ChartAxisLayer {
         fatalError("override")
     }
 
-    func labelMaybeSize(labelMaybe: ChartAxisLabel?) -> CGSize {
-        return labelMaybe?.textSize ?? CGSizeZero
-    }
-    
     final func screenLocForScalar(scalar: Double) -> CGFloat {
         if let firstScalar = self.axisValues.first?.scalar {
             return self.screenLocForScalar(scalar, firstAxisScalar: firstScalar)

--- a/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
@@ -49,7 +49,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
     
     private func generateAxisTitleLabelsDrawers(labels: [ChartAxisLabel], spacingLabelAxisX: CGFloat, spacingLabelBetweenAxis: CGFloat, offset: CGFloat) -> [ChartLabelDrawer] {
         
-        let rowHeights = self.rowHeightsForRows(rows: labels.map{[$0]})
+        let rowHeights = self.rowHeightsForRows(rows: labels.map { [$0] })
         
         return labels.enumerate().map{(index, label) in
             
@@ -121,9 +121,9 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
     
     // Get max text height for each row of axis values
     private func rowHeightsForRows(rows rows: [[ChartAxisLabel?]]) -> [CGFloat] {
-        return rows.map {row in
-            row.reduce(-1) {maxHeight, labelMaybe in
-                return max(maxHeight, self.labelMaybeSize(labelMaybe).height)
+        return rows.map { row in
+            row.flatMap { $0 }.reduce(-1) { maxHeight, label in
+                return max(maxHeight, label.textSize.height)
             }
         }
     }

--- a/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
@@ -49,7 +49,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
     
     private func generateAxisTitleLabelsDrawers(labels: [ChartAxisLabel], spacingLabelAxisX: CGFloat, spacingLabelBetweenAxis: CGFloat, offset: CGFloat) -> [ChartLabelDrawer] {
         
-        let rowHeights = self.rowHeightsForRows(rows: labels.map { [$0] })
+        let rowHeights = self.rowHeightsForRows(labels.map { [$0] })
         
         return labels.enumerate().map{(index, label) in
             
@@ -84,7 +84,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
             }
         }
         
-        return self.rowHeightsForRows(rows: rows)
+        return self.rowHeightsForRows(rows)
     }
     
     override func generateLabelDrawers(offset offset: CGFloat) -> [ChartLabelDrawer] {
@@ -120,7 +120,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
     
     
     // Get max text height for each row of axis values
-    private func rowHeightsForRows(rows rows: [[ChartAxisLabel?]]) -> [CGFloat] {
+    private func rowHeightsForRows(rows: [[ChartAxisLabel?]]) -> [CGFloat] {
         return rows.map { row in
             row.flatMap { $0 }.reduce(-1) { maxHeight, label in
                 return max(maxHeight, label.textSize.height)


### PR DESCRIPTION
This removes the labelMaybeSize method. It wasn't needed in two places where it was being used, and in the other its functionality was replaced by flatMapping the array of optionals to remove the optionals before doing the reduce.

I also removed an extraneous `rows` parameter label since it was already included in the method name.