### PR TITLE
Add public init so ChartLayerBase can be subclassed

### DIFF
--- a/SwiftCharts/Layers/ChartLayerBase.swift
+++ b/SwiftCharts/Layers/ChartLayerBase.swift
@@ -14,4 +14,6 @@ public class ChartLayerBase: ChartLayer {
     public func chartInitialized(chart chart: Chart) {}
     
     public func chartViewDrawing(context context: CGContextRef, chart: Chart) {}
+    
+    public init() {}
 }


### PR DESCRIPTION
Is `ChartLayerBase` available for subclassing? Currently, attempts to create a subclass from outside the module fail - Swift requires us to call `super.init()` in any subclass, but no designated initializer is visible.

We should either add a public initializer or mark it `final` to make it clear.

Thanks for your work on this project!