### PR TITLE
Make use of CustomStringConvertible, aggregate ChartAxisValue code in base class, another minor change

### DIFF
--- a/Examples/Examples/AreasExample.swift
+++ b/Examples/Examples/AreasExample.swift
@@ -88,7 +88,7 @@ class AreasExample: UIViewController {
                 let infoView = UILabel(frame: CGRectMake(0, 10, w, h - 30))
                 infoView.textColor = UIColor.whiteColor()
                 infoView.backgroundColor = UIColor.blackColor()
-                infoView.text = "Some text about \(chartPoint.text)"
+                infoView.text = "Some text about \(chartPoint)"
                 infoView.font = ExamplesDefaults.fontWithSize(Env.iPad ? 14 : 12)
                 infoView.textAlignment = NSTextAlignment.Center
                 

--- a/Examples/Examples/CoordsExample.swift
+++ b/Examples/Examples/CoordsExample.swift
@@ -39,13 +39,13 @@ class CoordsExample: UIViewController {
             let w: CGFloat = 70
             let h: CGFloat = 30
             
-            let text = "(\(chartPoint.x.text), \(chartPoint.y.text))"
+            let text = "(\(chartPoint.x), \(chartPoint.y))"
             let font = ExamplesDefaults.labelFont
             let textSize = ChartUtils.textSize(text, font: font)
             let x = min(screenLoc.x + 5, chart.bounds.width - textSize.width - 5)
             let view = UIView(frame: CGRectMake(x, screenLoc.y - h, w, h))
             let label = UILabel(frame: view.bounds)
-            label.text = "(\(chartPoint.x.text), \(chartPoint.y.text))"
+            label.text = "(\(chartPoint.x), \(chartPoint.y))"
             label.font = ExamplesDefaults.labelFont
             view.addSubview(label)
             view.alpha = 0

--- a/Examples/Examples/CustomUnitsExample.swift
+++ b/Examples/Examples/CustomUnitsExample.swift
@@ -114,7 +114,7 @@ class CustomUnitsExample: UIViewController {
     }
     
     class ChartAxisValuePercent: ChartAxisValueDouble {
-        override var text: String {
+        override var description: String {
             return "\(self.formatter.stringFromNumber(self.scalar)!)%"
         }
     }

--- a/Examples/Examples/HelloWorld.swift
+++ b/Examples/Examples/HelloWorld.swift
@@ -46,7 +46,7 @@ class HelloWorld: UIViewController {
             let label = UILabel(frame: CGRectMake(center.x - viewSize / 2, center.y - viewSize / 2, viewSize, viewSize))
             label.backgroundColor = UIColor.greenColor()
             label.textAlignment = NSTextAlignment.Center
-            label.text = "\(chartPointModel.chartPoint.y.text)"
+            label.text = chartPointModel.chartPoint.y.description
             label.font = ExamplesDefaults.labelFont
             return label
         }

--- a/SwiftCharts/AxisValues/ChartAxisValue.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValue.swift
@@ -9,31 +9,25 @@
 import UIKit
 
 /**
-    An axis value, which is represented internally by a double and provides the label which is displayed in the chart (or labels, in the case of working with multiple labels per axis value).
-    This class is not meant to be instantiated directly. Use one of the existing subclasses or create a new one.
-*/
+ A ChartAxisValue models a value along a particular chart axis. For example, two ChartAxisValues represent the two components of a ChartPoint. It has a backing Double scalar value, which provides a canonical form for all subclasses to be laid out along an axis. It also has one or more labels that are drawn in the chart.
+ This class is not meant to be instantiated directly. Use one of the existing subclasses or create a new one.
+ */
 public class ChartAxisValue: Equatable, CustomStringConvertible {
 
     public let scalar: Double
-    
-    /**
-        Labels that will be displayed on the chart. How this is done depends on the implementation of ChartAxisLayer.
-        In the most common case this will be an array with only one element.
-    */
+    public let labelSettings: ChartLabelSettings
+    public var hidden = false
+
+    /// The labels that will be displayed in the chart
     public var labels: [ChartAxisLabel] {
-        fatalError("Override")
+        let axisLabel = ChartAxisLabel(text: self.description, settings: self.labelSettings)
+        axisLabel.hidden = self.hidden
+        return [axisLabel]
     }
-    
-    public var hidden: Bool = false {
-        didSet {
-            for label in self.labels {
-                label.hidden = self.hidden
-            }
-        }
-    }
-  
-    public init(scalar: Double) {
+
+    public init(scalar: Double, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.scalar = scalar
+        self.labelSettings = labelSettings
     }
     
     public var copy: ChartAxisValue {
@@ -41,7 +35,7 @@ public class ChartAxisValue: Equatable, CustomStringConvertible {
     }
     
     public func copy(scalar: Double) -> ChartAxisValue {
-        return ChartAxisValue(scalar: scalar)
+        return ChartAxisValue(scalar: scalar, labelSettings: self.labelSettings)
     }
 
     // MARK: CustomStringConvertible

--- a/SwiftCharts/AxisValues/ChartAxisValue.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValue.swift
@@ -12,13 +12,9 @@ import UIKit
     An axis value, which is represented internally by a double and provides the label which is displayed in the chart (or labels, in the case of working with multiple labels per axis value).
     This class is not meant to be instantiated directly. Use one of the existing subclasses or create a new one.
 */
-public class ChartAxisValue: Equatable {
+public class ChartAxisValue: Equatable, CustomStringConvertible {
 
     public let scalar: Double
-   
-    public var text: String {
-        fatalError("Override")
-    }
     
     /**
         Labels that will be displayed on the chart. How this is done depends on the implementation of ChartAxisLayer.
@@ -46,6 +42,12 @@ public class ChartAxisValue: Equatable {
     
     public func copy(scalar: Double) -> ChartAxisValue {
         return ChartAxisValue(scalar: scalar)
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        return String(scalar)
     }
 }
 

--- a/SwiftCharts/AxisValues/ChartAxisValueDate.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDate.swift
@@ -36,5 +36,11 @@ public class ChartAxisValueDate: ChartAxisValue {
     public class func scalarFromDate(date: NSDate) -> Double {
         return Double(date.timeIntervalSince1970)
     }
+
+    // MARK: CustomStringConvertible
+
+    override public var description: String {
+        return self.formatter.stringFromDate(self.date)
+    }
 }
 

--- a/SwiftCharts/AxisValues/ChartAxisValueDate.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDate.swift
@@ -11,7 +11,6 @@ import UIKit
 public class ChartAxisValueDate: ChartAxisValue {
   
     private let formatter: NSDateFormatter
-    private let labelSettings: ChartLabelSettings
     
     public var date: NSDate {
         return ChartAxisValueDate.dateFromScalar(self.scalar)
@@ -19,14 +18,7 @@ public class ChartAxisValueDate: ChartAxisValue {
     
     public init(date: NSDate, formatter: NSDateFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.formatter = formatter
-        self.labelSettings = labelSettings
-        super.init(scalar: ChartAxisValueDate.scalarFromDate(date))
-    }
-    
-    override public var labels: [ChartAxisLabel] {
-        let axisLabel = ChartAxisLabel(text: self.formatter.stringFromDate(self.date), settings: self.labelSettings)
-        axisLabel.hidden = self.hidden
-        return [axisLabel]
+        super.init(scalar: ChartAxisValueDate.scalarFromDate(date), labelSettings: labelSettings)
     }
     
     public class func dateFromScalar(scalar: Double) -> NSDate {

--- a/SwiftCharts/AxisValues/ChartAxisValueDouble.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDouble.swift
@@ -13,9 +13,6 @@ public class ChartAxisValueDouble: ChartAxisValue {
     public let formatter: NSNumberFormatter
     let labelSettings: ChartLabelSettings
     
-    override public var text: String {
-        return self.formatter.stringFromNumber(self.scalar)!
-    }
 
     public convenience init(_ int: Int, formatter: NSNumberFormatter = ChartAxisValueDouble.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.init(Double(int), formatter: formatter, labelSettings: labelSettings)
@@ -42,4 +39,10 @@ public class ChartAxisValueDouble: ChartAxisValue {
         formatter.maximumFractionDigits = 2
         return formatter
     }()
+
+    // MARK: CustomStringConvertible
+
+    override public var description: String {
+        return self.formatter.stringFromNumber(self.scalar)!
+    }
 }

--- a/SwiftCharts/AxisValues/ChartAxisValueDouble.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDouble.swift
@@ -11,8 +11,6 @@ import UIKit
 public class ChartAxisValueDouble: ChartAxisValue {
     
     public let formatter: NSNumberFormatter
-    let labelSettings: ChartLabelSettings
-    
 
     public convenience init(_ int: Int, formatter: NSNumberFormatter = ChartAxisValueDouble.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.init(Double(int), formatter: formatter, labelSettings: labelSettings)
@@ -20,15 +18,8 @@ public class ChartAxisValueDouble: ChartAxisValue {
     
     public init(_ double: Double, formatter: NSNumberFormatter = ChartAxisValueDouble.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.formatter = formatter
-        self.labelSettings = labelSettings
-        super.init(scalar: double)
+        super.init(scalar: double, labelSettings: labelSettings)
     }
-    
-    override public var labels: [ChartAxisLabel] {
-        let axisLabel = ChartAxisLabel(text: self.text, settings: self.labelSettings)
-        return [axisLabel]
-    }
-    
     
     override public func copy(scalar: Double) -> ChartAxisValueDouble {
         return ChartAxisValueDouble(scalar, formatter: self.formatter, labelSettings: self.labelSettings)

--- a/SwiftCharts/AxisValues/ChartAxisValueDoubleScreenLoc.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDoubleScreenLoc.swift
@@ -15,11 +15,7 @@ public class ChartAxisValueDoubleScreenLoc: ChartAxisValueDouble {
     var screenLocDouble: Double {
         return self.scalar
     }
-    
-    override public var text: String {
-        return self.formatter.stringFromNumber(self.actualDouble)!
-    }
-    
+
     // screenLocFloat: model value which will be used to calculate screen position
     // actualFloat: scalar which this axis value really represents
     public init(screenLocDouble: Double, actualDouble: Double, formatter: NSNumberFormatter = ChartAxisValueFloat.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
@@ -30,5 +26,11 @@ public class ChartAxisValueDoubleScreenLoc: ChartAxisValueDouble {
     override public var labels: [ChartAxisLabel] {
         let axisLabel = ChartAxisLabel(text: self.text, settings: self.labelSettings)
         return [axisLabel]
+    }
+
+    // MARK: CustomStringConvertible
+    
+    override public var description: String {
+        return self.formatter.stringFromNumber(self.actualDouble)!
     }
 }

--- a/SwiftCharts/AxisValues/ChartAxisValueDoubleScreenLoc.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDoubleScreenLoc.swift
@@ -23,11 +23,6 @@ public class ChartAxisValueDoubleScreenLoc: ChartAxisValueDouble {
         super.init(screenLocDouble, formatter: formatter, labelSettings: labelSettings)
     }
     
-    override public var labels: [ChartAxisLabel] {
-        let axisLabel = ChartAxisLabel(text: self.text, settings: self.labelSettings)
-        return [axisLabel]
-    }
-
     // MARK: CustomStringConvertible
     
     override public var description: String {

--- a/SwiftCharts/AxisValues/ChartAxisValueFloat.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueFloat.swift
@@ -21,11 +21,7 @@ public class ChartAxisValueFloat: ChartAxisValue {
     public var float: CGFloat {
         return CGFloat(self.scalar)
     }
-  
-    override public var text: String {
-        return self.formatter.stringFromNumber(self.float)!
-    }
-    
+
     public init(_ float: CGFloat, formatter: NSNumberFormatter = ChartAxisValueFloat.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.formatter = formatter
         self.labelSettings = labelSettings
@@ -47,4 +43,10 @@ public class ChartAxisValueFloat: ChartAxisValue {
         formatter.maximumFractionDigits = 2
         return formatter
     }()
+
+    // MARK: CustomStringConvertible
+
+    override public var description: String {
+        return self.formatter.stringFromNumber(self.float)!
+    }
 }

--- a/SwiftCharts/AxisValues/ChartAxisValueFloat.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueFloat.swift
@@ -16,7 +16,6 @@ import UIKit
 public class ChartAxisValueFloat: ChartAxisValue {
     
     public let formatter: NSNumberFormatter
-    let labelSettings: ChartLabelSettings
 
     public var float: CGFloat {
         return CGFloat(self.scalar)
@@ -24,16 +23,9 @@ public class ChartAxisValueFloat: ChartAxisValue {
 
     public init(_ float: CGFloat, formatter: NSNumberFormatter = ChartAxisValueFloat.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.formatter = formatter
-        self.labelSettings = labelSettings
-        super.init(scalar: Double(float))
+        super.init(scalar: Double(float), labelSettings: labelSettings)
     }
    
-    override public var labels: [ChartAxisLabel] {
-        let axisLabel = ChartAxisLabel(text: self.text, settings: self.labelSettings)
-        return [axisLabel]
-    }
-    
-    
     override public func copy(scalar: Double) -> ChartAxisValueFloat {
         return ChartAxisValueFloat(CGFloat(scalar), formatter: self.formatter, labelSettings: self.labelSettings)
     }

--- a/SwiftCharts/AxisValues/ChartAxisValueFloatScreenLoc.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueFloatScreenLoc.swift
@@ -24,11 +24,6 @@ public class ChartAxisValueFloatScreenLoc: ChartAxisValueFloat {
         super.init(screenLocFloat, formatter: formatter, labelSettings: labelSettings)
     }
     
-    override public var labels: [ChartAxisLabel] {
-        let axisLabel = ChartAxisLabel(text: self.text, settings: self.labelSettings)
-        return [axisLabel]
-    }
-
     // MARK: CustomStringConvertible
 
     override public var description: String {

--- a/SwiftCharts/AxisValues/ChartAxisValueFloatScreenLoc.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueFloatScreenLoc.swift
@@ -17,10 +17,6 @@ public class ChartAxisValueFloatScreenLoc: ChartAxisValueFloat {
         return CGFloat(self.scalar)
     }
     
-    override public var text: String {
-        return self.formatter.stringFromNumber(self.actualFloat)!
-    }
-
     // screenLocFloat: model value which will be used to calculate screen position
     // actualFloat: scalar which this axis value really represents
     public init(screenLocFloat: CGFloat, actualFloat: CGFloat, formatter: NSNumberFormatter = ChartAxisValueFloat.defaultFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
@@ -31,5 +27,11 @@ public class ChartAxisValueFloatScreenLoc: ChartAxisValueFloat {
     override public var labels: [ChartAxisLabel] {
         let axisLabel = ChartAxisLabel(text: self.text, settings: self.labelSettings)
         return [axisLabel]
+    }
+
+    // MARK: CustomStringConvertible
+
+    override public var description: String {
+        return self.formatter.stringFromNumber(self.actualFloat)!
     }
 }

--- a/SwiftCharts/AxisValues/ChartAxisValueInt.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueInt.swift
@@ -11,18 +11,10 @@ import UIKit
 public class ChartAxisValueInt: ChartAxisValue {
 
     public let int: Int
-    private let labelSettings: ChartLabelSettings
-    
 
     public init(_ int: Int, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.int = int
-        self.labelSettings = labelSettings
-        super.init(scalar: Double(int))
-    }
-    
-    override public var labels:[ChartAxisLabel] {
-        let axisLabel = ChartAxisLabel(text: self.text, settings: self.labelSettings)
-        return [axisLabel]
+        super.init(scalar: Double(int), labelSettings: labelSettings)
     }
     
     override public func copy(scalar: Double) -> ChartAxisValueInt {

--- a/SwiftCharts/AxisValues/ChartAxisValueInt.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueInt.swift
@@ -13,10 +13,7 @@ public class ChartAxisValueInt: ChartAxisValue {
     public let int: Int
     private let labelSettings: ChartLabelSettings
     
-    override public var text: String {
-        return "\(self.int)"
-    }
-    
+
     public init(_ int: Int, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.int = int
         self.labelSettings = labelSettings
@@ -30,5 +27,11 @@ public class ChartAxisValueInt: ChartAxisValue {
     
     override public func copy(scalar: Double) -> ChartAxisValueInt {
         return ChartAxisValueInt(self.int, labelSettings: self.labelSettings)
+    }
+
+    // MARK: CustomStringConvertible
+    
+    override public var description: String {
+        return String(self.int)
     }
 }

--- a/SwiftCharts/AxisValues/ChartAxisValueString.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueString.swift
@@ -11,19 +11,12 @@ import UIKit
 public class ChartAxisValueString: ChartAxisValue {
    
     let string: String
-    private let labelSettings: ChartLabelSettings
     
     public init(_ string: String = "", order: Int, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.string = string
-        self.labelSettings = labelSettings
-        super.init(scalar: Double(order))
+        super.init(scalar: Double(order), labelSettings: labelSettings)
     }
     
-    override public var labels: [ChartAxisLabel] {
-        let axisLabel = ChartAxisLabel(text: self.string, settings: self.labelSettings)
-        return [axisLabel]
-    }
-
     // MARK: CustomStringConvertible
 
     override public var description: String {

--- a/SwiftCharts/AxisValues/ChartAxisValueString.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueString.swift
@@ -23,4 +23,10 @@ public class ChartAxisValueString: ChartAxisValue {
         let axisLabel = ChartAxisLabel(text: self.string, settings: self.labelSettings)
         return [axisLabel]
     }
+
+    // MARK: CustomStringConvertible
+
+    override public var description: String {
+        return self.string
+    }
 }

--- a/SwiftCharts/ChartPoint/ChartPoint.swift
+++ b/SwiftCharts/ChartPoint/ChartPoint.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class ChartPoint: Equatable {
+public class ChartPoint: Equatable, CustomStringConvertible {
     
     public let x: ChartAxisValue
     public let y: ChartAxisValue
@@ -18,7 +18,7 @@ public class ChartPoint: Equatable {
         self.y = y
     }
     
-    public var text: String {
+    public var description: String {
         return "\(self.x), \(self.y)"
     }
 }

--- a/SwiftCharts/ChartPoint/ChartPoint.swift
+++ b/SwiftCharts/ChartPoint/ChartPoint.swift
@@ -19,7 +19,7 @@ public class ChartPoint: Equatable {
     }
     
     public var text: String {
-        return "\(self.x.text), \(self.y.text)"
+        return "\(self.x), \(self.y)"
     }
 }
 

--- a/SwiftCharts/Layers/ChartPointsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLayer.swift
@@ -65,15 +65,15 @@ public class ChartPointsLayer<T: ChartPoint>: ChartCoordsSpaceLayer {
     }
     
     public func chartPointsForScreenLoc(screenLoc: CGPoint) -> [T] {
-        return self.chartPointsWith(filter: {$0 == screenLoc})
+        return self.filterChartPoints { $0 == screenLoc }
     }
     
     public func chartPointsForScreenLocX(x: CGFloat) -> [T] {
-        return self.chartPointsWith(filter: {$0.x == x})
+        return self.filterChartPoints { $0.x == x }
     }
     
     public func chartPointsForScreenLocY(y: CGFloat) -> [T] {
-        return self.chartPointsWith(filter: {$0.y == y})
+        return self.filterChartPoints { $0.y == y }
 
     }
 
@@ -95,13 +95,13 @@ public class ChartPointsLayer<T: ChartPoint>: ChartCoordsSpaceLayer {
         }.0
     }
     
-    private func chartPointsWith(filter filter: (CGPoint) -> Bool) -> [T] {
-        return self.chartPointsModels.reduce(Array<T>()) {u, chartPointModel in
+    private func filterChartPoints(includePoint: (CGPoint) -> Bool) -> [T] {
+        return self.chartPointsModels.reduce(Array<T>()) { includedPoints, chartPointModel in
             let chartPoint = chartPointModel.chartPoint
-            if filter(self.chartPointScreenLoc(chartPoint)) {
-                return u + [chartPoint]
+            if includePoint(self.chartPointScreenLoc(chartPoint)) {
+                return includedPoints + [chartPoint]
             } else {
-                return u
+                return includedPoints
             }
         }
     }

--- a/SwiftCharts/Layers/ChartPointsLineTrackerLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLineTrackerLayer.swift
@@ -216,7 +216,7 @@ public class ChartPointsLineTrackerLayer<T: ChartPoint>: ChartPointsLayer<T> {
                     let y = dummyModel.chartPoint.y.copy(yScalar)
                     let chartPoint = T(x: x, y: y)
                     
-                    self.currentPositionInfoOverlay(view: view).text = "Pos: \(chartPoint.text)"
+                    self.currentPositionInfoOverlay(view: view).text = "Pos: \(chartPoint)"
                 }
             }
         }

--- a/SwiftCharts/Utils/Trendlines/TrendlineGenerator.swift
+++ b/SwiftCharts/Utils/Trendlines/TrendlineGenerator.swift
@@ -42,8 +42,8 @@ public struct TrendlineGenerator {
         let last = chartPoints.last!
         
         return [
-            ChartPoint(x: ChartAxisValue(scalar: first.x.scalar), y: ChartAxisValue(scalar: y(first.x.scalar))),
-            ChartPoint(x: ChartAxisValue(scalar: last.x.scalar), y: ChartAxisValue(scalar: y(last.x.scalar)))
+            ChartPoint(x: ChartAxisValueDouble(first.x.scalar), y: ChartAxisValueDouble(y(first.x.scalar))),
+            ChartPoint(x: ChartAxisValueDouble(last.x.scalar), y: ChartAxisValueDouble(y(last.x.scalar)))
         ]
     }
 }

--- a/SwiftCharts/Views/ChartPointTextCircleView.swift
+++ b/SwiftCharts/Views/ChartPointTextCircleView.swift
@@ -35,7 +35,7 @@ public class ChartPointTextCircleView: UILabel {
         super.init(frame: CGRectMake(0, center.y - diameter / 2, diameter, diameter))
 
         self.textColor = UIColor.blackColor()
-        self.text = chartPoint.text
+        self.text = chartPoint.description
         self.font = font
         self.layer.cornerRadius = cornerRadius
         self.layer.borderWidth = borderWidth


### PR DESCRIPTION
This PR makes 3 kinds of changes. They probably could have been split up into separate PRs, so let me know if any of them would prevent merging this entirely.

1. Classes with a `text` property that mimicked `CustomStringConvertible`'s `description` have been changed to conform to that protocol instead.
2. Aggregated the common code from ChartAxisValue subclasses into the base class.
3. A small change to make a particular filtering method in ChartPointsLayer have a more similar signature to the standard library's `filter`.