### PR TITLE
Add an example of panning a scatter chart across a much larger underlying chart than fits on the screen

### DIFF
--- a/Examples/DetailViewController.swift
+++ b/Examples/DetailViewController.swift
@@ -48,6 +48,9 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate {
             case .Scatter:
                 self.setSplitSwipeEnabled(true)
                 self.showExampleController(ScatterExample())
+            case .PanScatter:
+                self.setSplitSwipeEnabled(true)
+                self.showExampleController(PanScatterExample())
             case .Notifications:
                 self.setSplitSwipeEnabled(true)
                 self.showExampleController(NotificationsExample())

--- a/Examples/Examples/PanScatterExample.swift
+++ b/Examples/Examples/PanScatterExample.swift
@@ -1,0 +1,165 @@
+//
+//  PanScatterExample.swift
+//  Examples
+//
+//  Created by iainbryson on 19/01/16.
+//  Copyright (c) 2016 iainbryson. All rights reserved.
+//
+/*
+This example shows how you can achieve a pan effect across a larger canvas than fits on screen.  We render the chart and axes into a frame which is 9 times the size of the visible portion of the chart -- essentially a 3 by 3 grid where the center square fills up the screen -- and allow panning around the area.  In order to keep the axes always in view, we split the chart into 3 separate views.  With appropriate clipping, this lets us scroll only the X portion of the x axis and the y portion of the y axis, so they're always visible and always show the current position in space.
+
+*/
+
+import UIKit
+import SwiftCharts
+
+private enum MyExampleModelDataType {
+    case Type0, Type1, Type2, Type3
+}
+
+private enum Shape {
+    case Triangle, Square, Circle, Cross
+}
+
+class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
+    
+    private var charts = [String:Chart]()
+    
+    let panRecognizer = UIPanGestureRecognizer()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        panRecognizer.addTarget(self, action: "panChart:")
+        panRecognizer.delegate = self
+        self.view.addGestureRecognizer(panRecognizer)
+
+        let labelSettings = ChartLabelSettings(font: ExamplesDefaults.labelFont)
+
+
+        // Create a regular model so it's easy to tell that the axes and points are aligned.
+        var models =  [(x: Double, y: Double, type: MyExampleModelDataType)]();
+
+        for x in 0.stride(through: 450, by: 25) {
+            for y in 0.stride(through: 450, by: 25) {
+                models.append((x: Double(x), y: Double(y), .Type0 ))
+            }
+        }
+        
+        let layerSpecifications: [MyExampleModelDataType : (shape: Shape, color: UIColor)] = [
+            .Type0 : (.Triangle, UIColor.redColor()),
+            .Type1 : (.Square, UIColor.blueColor()),
+            .Type2 : (.Circle, UIColor.greenColor()),
+            .Type3 : (.Cross, UIColor.blackColor())
+        ]
+
+        let innerChartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
+        let outerChartFrame = CGRectMake((innerChartFrame.origin.x - innerChartFrame.size.width),
+                                              (innerChartFrame.origin.y - innerChartFrame.size.height),
+                                              3.0 * innerChartFrame.size.width,
+                                              3.0 * innerChartFrame.size.height)
+
+        let xValues = 0.stride(through: 450, by: 50).map {ChartAxisValueInt($0, labelSettings: labelSettings)}
+        let yValues = 0.stride(through: 300, by: 50).map {ChartAxisValueInt($0, labelSettings: labelSettings)}
+        
+        let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: "X Axis title", settings: labelSettings))
+        let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Y Axis title", settings: labelSettings.defaultVertical()))
+        
+        let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: outerChartFrame, xModel: xModel, yModel: yModel)
+        let (xAxis, yAxis, _) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+
+        let innerCoordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: innerChartFrame, xModel: xModel, yModel: yModel)
+        let (_, _, innerFrame) = (innerCoordsSpace.xAxis, innerCoordsSpace.yAxis, innerCoordsSpace.chartInnerFrame)
+
+        
+        let scatterLayers = self.toLayers(models, layerSpecifications: layerSpecifications, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame)
+        
+        let guidelinesLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: guidelinesLayerSettings)
+
+        // Create the Chart for the plot area
+        let plotChart = Chart(
+            frame: outerChartFrame,
+            layers: [
+                guidelinesLayer
+                ] + scatterLayers
+        )
+        let plotAreaUIView = UIView(frame: CGRect(origin: CGPoint(x: innerCoordsSpace.chartInnerFrame.origin.x + innerChartFrame.origin.x, y: (innerCoordsSpace.chartInnerFrame.origin.y+innerChartFrame.origin.y)), size: innerCoordsSpace.chartInnerFrame.size))
+        plotAreaUIView.clipsToBounds = true
+        plotAreaUIView.backgroundColor = UIColor(colorLiteralRed: 0.9, green: 0.5, blue: 0.9, alpha: 0.05) // debug colors
+        plotAreaUIView.addSubview(plotChart.view)
+        self.view.addSubview(plotAreaUIView)
+
+        
+        // take the axes from the full-size chart and create a new chart with it so it gets it's own view.
+        let xAxisChart = Chart(frame: CGRect(origin: CGPointMake(outerChartFrame.origin.x + innerFrame.origin.x, outerChartFrame.origin.y + innerFrame.size.height*0.0), size: CGSize(width: outerChartFrame.size.width, height: outerChartFrame.size.height) ), layers: [coordsSpace.xAxis])
+        xAxisChart.view.backgroundColor = UIColor(colorLiteralRed: 0.9, green: 0.5, blue: 0.9, alpha: 0.05) // debug colors
+        xAxisChart.view.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, 0.0, -1*innerChartFrame.size.height)
+        
+        let yAxisChart = Chart(frame: CGRect(origin: CGPointMake(outerChartFrame.origin.x - ExamplesDefaults.chartSettings.axisTitleLabelsToLabelsSpacing, outerChartFrame.origin.y), size: CGSize(width: coordsSpace.chartInnerFrame.origin.x, height: outerChartFrame.size.height)), layers: [coordsSpace.yAxis])
+        yAxisChart.view.backgroundColor = UIColor(colorLiteralRed: 0.9, green: 0.9, blue: 0.5, alpha: 0.05) // debug colors
+        yAxisChart.view.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, +innerChartFrame.size.width, 0.0)
+        
+        // view to clip out the bottom left rectangular region where the axes would tend to overlap each other
+        let axisClipperSubview = UIView(frame: CGRect(origin: CGPoint(x: innerChartFrame.origin.x, y: (innerCoordsSpace.chartInnerFrame.origin.y+innerChartFrame.origin.y)), size: CGSizeMake(innerFrame.origin.x, innerFrame.size.height)))
+        axisClipperSubview.clipsToBounds = true;
+        
+        // we can chose to clip either x or y ticks
+        //axisClipperSubview.addSubview(xAxisChart.view)
+        axisClipperSubview.addSubview(yAxisChart.view)
+        
+        self.view.addSubview(axisClipperSubview)
+        self.view.addSubview(xAxisChart.view)
+        //self.view.addSubview(yAxisChart.view)
+
+        // Create the Chart for the x axis area
+        
+        self.charts = ["x" : xAxisChart, "plot" : plotChart, "y" : yAxisChart]
+    }
+    
+    private func toLayers(models: [(x: Double, y: Double, type: MyExampleModelDataType)], layerSpecifications: [MyExampleModelDataType : (shape: Shape, color: UIColor)], xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect) -> [ChartLayer] {
+        
+        // group chartpoints by type
+        let groupedChartPoints: Dictionary<MyExampleModelDataType, [ChartPoint]> = models.reduce(Dictionary<MyExampleModelDataType, [ChartPoint]>()) {(var dict, model) in
+            let chartPoint = ChartPoint(x: ChartAxisValueDouble(model.x), y: ChartAxisValueDouble(model.y))
+            if dict[model.type] != nil {
+                dict[model.type]!.append(chartPoint)
+                
+            } else {
+                dict[model.type] = [chartPoint]
+            }
+            return dict
+        }
+        
+        // create layer for each group
+        let dim: CGFloat = Env.iPad ? 14 : 7
+        let size = CGSizeMake(dim, dim)
+        let layers: [ChartLayer] = groupedChartPoints.map {(type, chartPoints) in
+            let layerSpecification = layerSpecifications[type]!
+            switch layerSpecification.shape {
+            case .Triangle:
+                return ChartPointsScatterTrianglesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+            case .Square:
+                return ChartPointsScatterSquaresLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+            case .Circle:
+                return ChartPointsScatterCirclesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+            case .Cross:
+                return ChartPointsScatterCrossesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+            }
+        }
+        
+        return layers
+    }
+
+
+    func panChart(pinchRecognizer: UIPinchGestureRecognizer) {
+        let translation = panRecognizer.translationInView(self.view);
+
+        self.charts["plot"]!.view.transform = CGAffineTransformTranslate(self.charts["plot"]!.view.transform, translation.x, translation.y)
+        self.charts["x"]!.view.transform = CGAffineTransformTranslate(self.charts["x"]!.view.transform, translation.x, 0.0)
+        self.charts["y"]!.view.transform = CGAffineTransformTranslate(self.charts["y"]!.view.transform, 0.0, translation.y)
+
+        panRecognizer.setTranslation(CGPointZero, inView: self.view)
+        print(translation)
+    }
+}

--- a/Examples/Examples/PanScatterExample.swift
+++ b/Examples/Examples/PanScatterExample.swift
@@ -75,7 +75,7 @@ class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
         let scatterLayers = self.toLayers(models, layerSpecifications: layerSpecifications, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame)
         
         let guidelinesLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: guidelinesLayerSettings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: coordsSpace.chartInnerFrame, settings: guidelinesLayerSettings)
 
         // Create the Chart for the plot area
         let plotChart = Chart(
@@ -104,16 +104,18 @@ class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
         let axisClipperSubview = UIView(frame: CGRect(origin: CGPoint(x: innerChartFrame.origin.x, y: (innerCoordsSpace.chartInnerFrame.origin.y+innerChartFrame.origin.y)), size: CGSizeMake(innerFrame.origin.x, innerFrame.size.height)))
         axisClipperSubview.clipsToBounds = true;
         
-        // we can chose to clip either x or y ticks
-        //axisClipperSubview.addSubview(xAxisChart.view)
-        axisClipperSubview.addSubview(yAxisChart.view)
+        // we can chose to clip either x or y:
         
-        self.view.addSubview(axisClipperSubview)
-        self.view.addSubview(xAxisChart.view)
+        // Y axis clips x Axis
+        //axisClipperSubview.addSubview(xAxisChart.view)
         //self.view.addSubview(yAxisChart.view)
 
-        // Create the Chart for the x axis area
-        
+        // X axis clips Y Axis
+        axisClipperSubview.addSubview(yAxisChart.view)
+        self.view.addSubview(xAxisChart.view)
+
+        self.view.addSubview(axisClipperSubview)
+
         self.charts = ["x" : xAxisChart, "plot" : plotChart, "y" : yAxisChart]
     }
     

--- a/Examples/Examples/PanScatterExample.swift
+++ b/Examples/Examples/PanScatterExample.swift
@@ -21,6 +21,42 @@ private enum Shape {
     case Triangle, Square, Circle, Cross
 }
 
+public class SimpleAxisLabelView: UIView {
+    
+    weak var chart: Chart?
+    var axisLabelDrawer: ChartLabelDrawer?
+    
+    public init(frame: CGRect, text: String, settings: ChartLabelSettings, chart: Chart) {
+        super.init(frame: frame)
+        self.sharedInit()
+
+        self.chart = chart // ugly
+        
+        let axisLabel = ChartAxisLabel(text: text, settings: settings)
+        let labelSize = ChartUtils.textSize(axisLabel.text, font: settings.font)
+        let settings = settings
+        let newSettings = ChartLabelSettings(font: settings.font, fontColor: settings.fontColor, rotation: settings.rotation, rotationKeep: settings.rotationKeep)
+        self.axisLabelDrawer = ChartLabelDrawer(text: axisLabel.text, screenLoc: CGPointMake(
+            frame.origin.x + (frame.size.width / 2) + labelSize.height,
+            (frame.size.height - 0.0 - labelSize.height)), settings: newSettings)
+        
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.sharedInit()
+    }
+    
+    func sharedInit() {
+        self.backgroundColor = UIColor.clearColor()
+    }
+    
+    override public func drawRect(rect: CGRect) {
+        let context = UIGraphicsGetCurrentContext()
+        axisLabelDrawer!.draw(context: context!, chart: chart!)
+    }
+}
+
 class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
     
     private var charts = [String:Chart]()
@@ -53,7 +89,14 @@ class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
             .Type3 : (.Cross, UIColor.blackColor())
         ]
 
-        let visibleChartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
+        let axisLabelHeight = CGFloat(20.0)
+        
+        // Use the whole superview, but carve out some space for the axis labels
+        let visibleChartFrame = CGRectMake(self.view.bounds.origin.x + axisLabelHeight,
+                                                self.view.bounds.origin.y,
+                                                self.view.bounds.size.width - axisLabelHeight,
+                                                self.view.bounds.size.height - axisLabelHeight)
+        
         let underlyingChartFrame = CGRectMake((visibleChartFrame.origin.x - visibleChartFrame.size.width),
                                               (visibleChartFrame.origin.y - visibleChartFrame.size.height),
                                               3.0 * visibleChartFrame.size.width,
@@ -62,10 +105,10 @@ class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
         let xValues = 0.stride(through: 450, by: 50).map {ChartAxisValueInt($0, labelSettings: labelSettings)}
         let yValues = 0.stride(through: 300, by: 50).map {ChartAxisValueInt($0, labelSettings: labelSettings)}
         
-        let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: "X Axis title", settings: labelSettings))
-        let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Y Axis title", settings: labelSettings.defaultVertical()))
+        let xModel = ChartAxisModel(axisValues: xValues)
+        let yModel = ChartAxisModel(axisValues: yValues)
         
-        // TODO: This default CoordsSapce up being very wastefu when we split out the elements into their own views.  Because the various elements (x axis, y axis and plot area) are positioned by this helper relative to a larger underlying canvas, by default we'd need to allocate UIViews of the size of the underlying frame for each of them, tripling our memory consumption.
+        // TODO: This default CoordsSapce up being very wasteful when we split out the elements into their own views.  Because the various elements (x axis, y axis and plot area) are positioned by this helper relative to a larger underlying canvas, by default we'd need to allocate UIViews of the size of the underlying frame for each of them, tripling our memory consumption.
         // This problem can be avoided for the y axis since it "hugs" the left border (and we an create a tall, narrow UIView without needing to allocate a whole extra chart-sized one), and is not a huge deal for the plot area since the only space we need to waste is the offset where the y axis lives -- it already is mostly the size of the underlying frame.  But it's a big problem for the x axis as we end up having to allocate an UIView the entire size of the underlying frame so that it can render at the bottom of this frame.
         let underlyingCoordSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: underlyingChartFrame, xModel: xModel, yModel: yModel)
         let (xAxis, yAxis, _) = (underlyingCoordSpace.xAxis, underlyingCoordSpace.yAxis, underlyingCoordSpace.chartInnerFrame)
@@ -88,22 +131,23 @@ class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
         )
         let plotAreaUIView = UIView(frame: CGRect(origin: CGPoint(x: visibleCoordSpace.chartInnerFrame.origin.x + visibleChartFrame.origin.x, y: (visibleCoordSpace.chartInnerFrame.origin.y+visibleChartFrame.origin.y)), size: visibleCoordSpace.chartInnerFrame.size))
         plotAreaUIView.clipsToBounds = true
-        plotAreaUIView.backgroundColor = UIColor(colorLiteralRed: 0.9, green: 0.5, blue: 0.9, alpha: 0.05) // debug colors
+        plotAreaUIView.backgroundColor = UIColor(red: 0.9, green: 0.5, blue: 0.9, alpha: 0.05) // debug colors
         plotAreaUIView.addSubview(plotChart.view)
         self.view.addSubview(plotAreaUIView)
 
         
         // take the axes from the full-size chart and create a new chart with it so it gets it's own view.
+
         let xAxisChart = Chart(frame: CGRect(origin: CGPointMake(underlyingChartFrame.origin.x + innerFrame.origin.x, underlyingChartFrame.origin.y + innerFrame.size.height*0.0), size: CGSize(width: underlyingChartFrame.size.width, height: underlyingChartFrame.size.height) ), layers: [underlyingCoordSpace.xAxis])
-        xAxisChart.view.backgroundColor = UIColor(colorLiteralRed: 0.9, green: 0.5, blue: 0.9, alpha: 0.05) // debug colors
+        xAxisChart.view.backgroundColor = UIColor(red: 0.9, green: 0.5, blue: 0.9, alpha: 0.05) // debug colors
         xAxisChart.view.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, 0.0, -1*visibleChartFrame.size.height)
         
-        let yAxisChart = Chart(frame: CGRect(origin: CGPointMake(underlyingChartFrame.origin.x - ExamplesDefaults.chartSettings.axisTitleLabelsToLabelsSpacing, underlyingChartFrame.origin.y), size: CGSize(width: underlyingCoordSpace.chartInnerFrame.origin.x, height: underlyingChartFrame.size.height)), layers: [underlyingCoordSpace.yAxis])
-        yAxisChart.view.backgroundColor = UIColor(colorLiteralRed: 0.9, green: 0.9, blue: 0.5, alpha: 0.05) // debug colors
+        let yAxisChart = Chart(frame: CGRect(origin: CGPointMake(underlyingChartFrame.origin.x - visibleChartFrame.origin.x, underlyingChartFrame.origin.y), size: CGSize(width: underlyingCoordSpace.chartInnerFrame.origin.x, height: underlyingChartFrame.size.height)), layers: [underlyingCoordSpace.yAxis])
+        yAxisChart.view.backgroundColor = UIColor(red: 0.9, green: 0.9, blue: 0.5, alpha: 0.05) // debug colors
         yAxisChart.view.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, +visibleChartFrame.size.width, 0.0)
         
         // view to clip out the bottom left rectangular region where the axes would tend to overlap each other
-        let axisClipperSubview = UIView(frame: CGRect(origin: CGPoint(x: visibleChartFrame.origin.x, y: (visibleCoordSpace.chartInnerFrame.origin.y+visibleChartFrame.origin.y)), size: CGSizeMake(innerFrame.origin.x, innerFrame.size.height)))
+        let axisClipperSubview = UIView(frame: CGRect(origin: CGPoint(x: visibleChartFrame.origin.x, y: (visibleCoordSpace.chartInnerFrame.origin.y + visibleChartFrame.origin.y)), size: CGSizeMake(innerFrame.origin.x, innerFrame.size.height)))
         axisClipperSubview.clipsToBounds = true;
         
         // we can chose to clip either x or y:
@@ -117,6 +161,12 @@ class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
         self.view.addSubview(xAxisChart.view)
 
         self.view.addSubview(axisClipperSubview)
+        
+        let xAxisView = SimpleAxisLabelView(frame: visibleChartFrame, text: "X Axis title", settings: labelSettings, chart: plotChart)
+        let yAxisView = SimpleAxisLabelView(frame: visibleChartFrame, text: "Y Axis title", settings: labelSettings.defaultVertical(), chart: plotChart)
+
+        self.view.addSubview(xAxisView)
+        self.view.addSubview(yAxisView)
 
         self.charts = ["x" : xAxisChart, "plot" : plotChart, "y" : yAxisChart]
     }

--- a/Examples/Examples/PanScatterExample.swift
+++ b/Examples/Examples/PanScatterExample.swift
@@ -26,19 +26,17 @@ public class SimpleAxisLabelView: UIView {
     weak var chart: Chart?
     var axisLabelDrawer: ChartLabelDrawer?
     
-    public init(frame: CGRect, text: String, settings: ChartLabelSettings, chart: Chart) {
+    public init(frame: CGRect, text: String, settings: ChartLabelSettings, chart: Chart, position: CGPoint) {
         super.init(frame: frame)
         self.sharedInit()
 
-        self.chart = chart // ugly
+        self.chart = chart // ugly: we don't really need a chart, except to draw with the ChartLabelDrawer
         
         let axisLabel = ChartAxisLabel(text: text, settings: settings)
         let labelSize = ChartUtils.textSize(axisLabel.text, font: settings.font)
         let settings = settings
         let newSettings = ChartLabelSettings(font: settings.font, fontColor: settings.fontColor, rotation: settings.rotation, rotationKeep: settings.rotationKeep)
-        self.axisLabelDrawer = ChartLabelDrawer(text: axisLabel.text, screenLoc: CGPointMake(
-            frame.origin.x + (frame.size.width / 2) + labelSize.height,
-            (frame.size.height - 0.0 - labelSize.height)), settings: newSettings)
+        self.axisLabelDrawer = ChartLabelDrawer(text: axisLabel.text, screenLoc: position, settings: newSettings)
         
     }
     
@@ -162,8 +160,13 @@ class PanScatterExample: UIViewController, UIGestureRecognizerDelegate {
 
         self.view.addSubview(axisClipperSubview)
         
-        let xAxisView = SimpleAxisLabelView(frame: visibleChartFrame, text: "X Axis title", settings: labelSettings, chart: plotChart)
-        let yAxisView = SimpleAxisLabelView(frame: visibleChartFrame, text: "Y Axis title", settings: labelSettings.defaultVertical(), chart: plotChart)
+        let xAxisView = SimpleAxisLabelView(frame: visibleChartFrame, text: "X Axis title", settings: labelSettings, chart: plotChart, position: CGPointMake(
+            (visibleChartFrame.size.width / 2),
+            (visibleChartFrame.size.height - 12))
+        )
+        let yAxisView = SimpleAxisLabelView(frame: visibleChartFrame, text: "Y Axis title", settings: labelSettings.defaultVertical(), chart: plotChart, position: CGPointMake(
+            0,
+            visibleChartFrame.size.height / 2))
 
         self.view.addSubview(xAxisView)
         self.view.addSubview(yAxisView)

--- a/Examples/Interface/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/Interface/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,80 +1,85 @@
 {
   "images" : [
     {
-      "idiom" : "iphone",
       "size" : "29x29",
-      "scale" : "2x",
-      "filename" : "Icon-Small@2x.png"
+      "idiom" : "iphone",
+      "filename" : "Icon-Small@2x.png",
+      "scale" : "2x"
     },
     {
-      "idiom" : "iphone",
       "size" : "29x29",
-      "scale" : "3x",
-      "filename" : "Icon-Small@3x.png"
+      "idiom" : "iphone",
+      "filename" : "Icon-Small@3x.png",
+      "scale" : "3x"
     },
     {
-      "idiom" : "iphone",
       "size" : "40x40",
-      "scale" : "2x",
-      "filename" : "Icon-40@2x.png"
+      "idiom" : "iphone",
+      "filename" : "Icon-40@2x.png",
+      "scale" : "2x"
     },
     {
-      "idiom" : "iphone",
       "size" : "40x40",
-      "scale" : "3x",
-      "filename" : "Icon-40@3x.png"
+      "idiom" : "iphone",
+      "filename" : "Icon-40@3x.png",
+      "scale" : "3x"
     },
     {
-      "idiom" : "iphone",
       "size" : "60x60",
-      "scale" : "2x",
-      "filename" : "Icon-60@2x.png"
-    },
-    {
       "idiom" : "iphone",
+      "filename" : "Icon-60@2x.png",
+      "scale" : "2x"
+    },
+    {
       "size" : "60x60",
-      "scale" : "3x",
-      "filename" : "Icon-60@3x.png"
+      "idiom" : "iphone",
+      "filename" : "Icon-60@3x.png",
+      "scale" : "3x"
     },
     {
-      "idiom" : "ipad",
       "size" : "29x29",
-      "scale" : "1x",
-      "filename" : "Icon-Small.png"
+      "idiom" : "ipad",
+      "filename" : "Icon-Small.png",
+      "scale" : "1x"
     },
     {
-      "idiom" : "ipad",
       "size" : "29x29",
-      "scale" : "2x",
-      "filename" : "Icon-Small@2x.png"
+      "idiom" : "ipad",
+      "filename" : "Icon-Small@2x.png",
+      "scale" : "2x"
     },
     {
-      "idiom" : "ipad",
       "size" : "40x40",
-      "scale" : "1x",
-      "filename" : "Icon-40.png"
+      "idiom" : "ipad",
+      "filename" : "Icon-40.png",
+      "scale" : "1x"
     },
     {
-      "idiom" : "ipad",
       "size" : "40x40",
-      "scale" : "2x",
-      "filename" : "Icon-40@2x.png"
+      "idiom" : "ipad",
+      "filename" : "Icon-40@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "76x76",
+      "idiom" : "ipad",
+      "filename" : "Icon-76.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "76x76",
+      "idiom" : "ipad",
+      "filename" : "Icon-76@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x",
-      "filename" : "Icon-76.png"
-    },
-    {
-      "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x",
-      "filename" : "Icon-76@2x.png"
+      "size" : "83.5x83.5",
+      "scale" : "2x"
     }
   ],
   "info" : {
     "version" : 1,
-    "author" : "makeappicon"
+    "author" : "xcode"
   }
 }

--- a/Examples/MasterViewController.swift
+++ b/Examples/MasterViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 
 enum Example {
-    case HelloWorld, Bars, StackedBars, BarsPlusMinus, GroupedBars, BarsStackedGrouped, Scatter, Areas, Bubble, Coords, Target, Multival, Notifications, Combination, Scroll, EqualSpacing, Tracker, MultiAxis, MultiAxisInteractive, CandleStick, Cubiclines, NotNumeric, CandleStickInteractive, CustomUnits, Trendline
+    case HelloWorld, Bars, StackedBars, BarsPlusMinus, GroupedBars, BarsStackedGrouped, Scatter, Areas, Bubble, Coords, Target, Multival, Notifications, Combination, Scroll, EqualSpacing, Tracker, MultiAxis, MultiAxisInteractive, CandleStick, Cubiclines, NotNumeric, CandleStickInteractive, CustomUnits, Trendline, PanScatter
 }
 
 class MasterViewController: UITableViewController {
@@ -25,6 +25,7 @@ class MasterViewController: UITableViewController {
         (.BarsStackedGrouped, "Stacked, grouped bars"),
         (.Combination, "+/- bars and line"),
         (.Scatter, "Scatter"),
+        (.PanScatter, "PanScatter"),
         (.Notifications, "Notifications (interactive)"),
         (.Target, "Target point animation"),
         (.Areas, "Areas, lines, circles (interactive)"),

--- a/SwiftCharts.xcodeproj/project.pbxproj
+++ b/SwiftCharts.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		22DBFFFE1BF5BF3900070F15 /* ChartAxisValueDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB08E2321B93A15E0030081C /* ChartAxisValueDouble.swift */; };
 		22DBFFFF1BF5BF3900070F15 /* ChartAxisValueFloatScreenLoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06405DD21B8AA81D00A689FF /* ChartAxisValueFloatScreenLoc.swift */; };
 		22E702171BF5B96200C19675 /* SwiftCharts.h in Headers */ = {isa = PBXBuildFile; fileRef = 06405DAB1B8AA74700A689FF /* SwiftCharts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5A40B0B1C4F0EAA006A5714 /* PanScatterExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A40B0A1C4F0EAA006A5714 /* PanScatterExample.swift */; };
 		EB08E2331B93A15E0030081C /* ChartAxisValueDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB08E2321B93A15E0030081C /* ChartAxisValueDouble.swift */; };
 		EB4CE97F1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4CE97E1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift */; };
 		EB9B7E6B1BB8A575001B89D4 /* StraightLinePathGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9B7E6A1BB8A575001B89D4 /* StraightLinePathGenerator.swift */; };
@@ -320,6 +321,7 @@
 		06405E0C1B8AA81D00A689FF /* InfoBubble.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoBubble.swift; sourceTree = "<group>"; };
 		067510C01B8AB36500A37F64 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main_iPhone.storyboard; sourceTree = "<group>"; };
 		22E7020F1BF5B8EC00C19675 /* SwiftCharts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCharts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5A40B0A1C4F0EAA006A5714 /* PanScatterExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanScatterExample.swift; sourceTree = "<group>"; };
 		EB08E2321B93A15E0030081C /* ChartAxisValueDouble.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisValueDouble.swift; sourceTree = "<group>"; };
 		EB4CE97E1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisValueDoubleScreenLoc.swift; sourceTree = "<group>"; };
 		EB9B7E6A1BB8A575001B89D4 /* StraightLinePathGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StraightLinePathGenerator.swift; sourceTree = "<group>"; };
@@ -393,6 +395,7 @@
 				062D238B1B8AAE5D0017ABB8 /* TargetExample.swift */,
 				062D238C1B8AAE5D0017ABB8 /* TrackerExample.swift */,
 				062D238D1B8AAE5D0017ABB8 /* TrendlineExample.swift */,
+				A5A40B0A1C4F0EAA006A5714 /* PanScatterExample.swift */,
 			);
 			path = Examples;
 			sourceTree = "<group>";
@@ -756,6 +759,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				06342ACA1B8AAD7F001C9F5D /* DetailViewController.swift in Sources */,
+				A5A40B0B1C4F0EAA006A5714 /* PanScatterExample.swift in Sources */,
 				062D23A51B8AAE5D0017ABB8 /* ScatterExample.swift in Sources */,
 				062D23AA1B8AAE5D0017ABB8 /* TrendlineExample.swift in Sources */,
 				062D23A21B8AAE5D0017ABB8 /* MultipleLabelsExample.swift in Sources */,

--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -9,11 +9,11 @@
 import UIKit
 
 public class ChartLabelSettings {
-    let font: UIFont
-    let fontColor: UIColor
-    let rotation: CGFloat
-    let rotationKeep: ChartLabelDrawerRotationKeep
-    let shiftXOnRotation: Bool
+    public let font: UIFont
+    public let fontColor: UIColor
+    public let rotation: CGFloat
+    public let rotationKeep: ChartLabelDrawerRotationKeep
+    public let shiftXOnRotation: Bool
     
     public init(font: UIFont = UIFont.systemFontOfSize(14), fontColor: UIColor = UIColor.blackColor(), rotation: CGFloat = 0, rotationKeep: ChartLabelDrawerRotationKeep = .Center, shiftXOnRotation: Bool = true) {
         self.font = font
@@ -57,7 +57,7 @@ public class ChartLabelDrawer: ChartContextDrawer {
         return ChartUtils.textSize(self.text, font: self.settings.font)
     }
     
-    init(text: String, screenLoc: CGPoint, settings: ChartLabelSettings) {
+    public init(text: String, screenLoc: CGPoint, settings: ChartLabelSettings) {
         self.text = text
         self.screenLoc = screenLoc
         self.settings = settings
@@ -67,7 +67,7 @@ public class ChartLabelDrawer: ChartContextDrawer {
         self.transform = self.transform(screenLoc, settings: settings)
     }
 
-    override func draw(context context: CGContextRef, chart: Chart) {
+    override public func draw(context context: CGContextRef, chart: Chart) {
         let labelSize = self.size
         
         let labelX = self.screenLoc.x


### PR DESCRIPTION
This is an example which shows how to create an independent pan between the x axis, y axis and points area.  Because the axes scroll independently, they're always visible, so you always know where you are.
