### PR TITLE
Use a simple closure to map dates instead of requiring a date formatter

### DIFF
--- a/SwiftCharts/AxisValues/ChartAxisValueDate.swift
+++ b/SwiftCharts/AxisValues/ChartAxisValueDate.swift
@@ -10,15 +10,19 @@ import UIKit
 
 public class ChartAxisValueDate: ChartAxisValue {
   
-    private let formatter: NSDateFormatter
-    
+    private let formatter: (NSDate) -> String
+
     public var date: NSDate {
         return ChartAxisValueDate.dateFromScalar(self.scalar)
     }
-    
-    public init(date: NSDate, formatter: NSDateFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
+
+    public init(date: NSDate, formatter: (NSDate) -> String, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
         self.formatter = formatter
         super.init(scalar: ChartAxisValueDate.scalarFromDate(date), labelSettings: labelSettings)
+    }
+
+    convenience public init(date: NSDate, formatter: NSDateFormatter, labelSettings: ChartLabelSettings = ChartLabelSettings()) {
+        self.init(date: date, formatter: { formatter.stringFromDate($0) }, labelSettings: labelSettings)
     }
     
     public class func dateFromScalar(scalar: Double) -> NSDate {
@@ -32,7 +36,7 @@ public class ChartAxisValueDate: ChartAxisValue {
     // MARK: CustomStringConvertible
 
     override public var description: String {
-        return self.formatter.stringFromDate(self.date)
+        return self.formatter(self.date)
     }
 }
 


### PR DESCRIPTION
Being able to use a function would be extremely convenient in our application, we don't expose NSDateFormatters to everyone.