### PR TITLE
Change ChartBaseView subclassing model

### DIFF
--- a/SwiftCharts/Chart.swift
+++ b/SwiftCharts/Chart.swift
@@ -49,8 +49,8 @@ public class ChartSettings {
 public class Chart {
 
     /// The view that the chart is drawn in
-    public let view: ChartBaseView
-
+    public let view: ChartView
+    
     /// The layers of the chart that are drawn in the view
     private let layers: [ChartLayer]
 
@@ -74,8 +74,8 @@ public class Chart {
 
      - returns: The new Chart
      */
-    public init(view: ChartBaseView, layers: [ChartLayer]) {
-
+    public init(view: ChartView, layers: [ChartLayer]) {
+        
         self.layers = layers
         
         self.view = view
@@ -132,8 +132,15 @@ public class Chart {
 }
 
 /// A UIView subclass for drawing charts
-public class ChartBaseView: UIView {
+public class ChartBaseView: ChartView {
+    
+    override public func drawRect(rect: CGRect) {
+        self.chart?.drawRect(rect)
+    }
+}
 
+public class ChartView: UIView {
+    
     /// The chart that will be drawn in this view
     weak var chart: Chart?
     
@@ -152,9 +159,5 @@ public class ChartBaseView: UIView {
      */
     func sharedInit() {
         self.backgroundColor = UIColor.clearColor()
-    }
-
-    override public func drawRect(rect: CGRect) {
-        self.chart?.drawRect(rect)
     }
 }


### PR DESCRIPTION
Change subclassing model for ChartBaseView so that it's possible to create a base view for Chart without drawRect method implemented.

Without this change drawRect method is always called but not always it's necessary (i.e. when all layers are added as sublayers instead of drawing on the context). As Apple says: "Implement this method if your view draws custom content. If your view does not do any custom drawing, avoid overriding this method."

In my case when I have a huge graph (around 60xiPad screen wide) I don't want to draw it using drawRect method - instead I would like to add only CALayers which causes significant memory consumption savings (with empty graph drawn using drawRect method memory jumps to 500mb).
