### PR TITLE
Set APPLICATION_EXTENSION_API_ONLY to YES

### DIFF
--- a/SwiftCharts.xcodeproj/project.pbxproj
+++ b/SwiftCharts.xcodeproj/project.pbxproj
@@ -1029,6 +1029,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1080,6 +1081,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
This allows using `SwiftCharts` from a framework. It avoids the following warning:
```
ld: warning: linking against a dylib which is not safe for use in application extensions: SwiftCharts.framework/SwiftCharts
```