### PR TITLE
ChartAxisModel: added precondition to ensure axis is not empty

### DIFF
--- a/SwiftCharts/Axis/ChartAxisModel.swift
+++ b/SwiftCharts/Axis/ChartAxisModel.swift
@@ -56,6 +56,8 @@ open class ChartAxisModel {
 
     /// Convenience initializer to pass a fixed axis value array. The array is mapped to axis values and label generators. 
     public convenience init(axisValues: [ChartAxisValue], lineColor: UIColor = UIColor.black, axisTitleLabels: [ChartAxisLabel] = [], labelsConflictSolver: ChartAxisLabelsConflictSolver? = nil, leadingPadding: ChartAxisPadding = .none, trailingPadding: ChartAxisPadding = .none, labelSpaceReservationMode: AxisLabelsSpaceReservationMode = .minPresentedSize, clipContents: Bool = false) {
+        precondition(!axisValues.isEmpty, "Axis cannot be empty")
+        
         var scalars: [Double] = []
         var dict = [Double: [ChartAxisLabel]]()
         for axisValue in axisValues {
@@ -65,7 +67,7 @@ open class ChartAxisModel {
             }
 
         }
-        let (firstModelValue, lastModelValue) = axisValues.isEmpty ? (0, 0) : (axisValues.first!.scalar, axisValues.last!.scalar)
+        let (firstModelValue, lastModelValue) = (axisValues.first!.scalar, axisValues.last!.scalar)
         
         let fixedArrayGenerator = ChartAxisValuesGeneratorFixed(values: scalars)
         let fixedLabelGenerator = ChartAxisLabelsGeneratorFixed(dict: dict)


### PR DESCRIPTION
This leads to a later crash (a point is generated with a `NaN` value which makes UIKit crash).
This can be reproduced by making one of the 2 axis in `StackedBarsExample` empty.