### PR TITLE
Changed ChartSettings and ChartSettingsZoomPan to struct

### DIFF
--- a/Examples/Examples/AreasExample.swift
+++ b/Examples/Examples/AreasExample.swift
@@ -30,7 +30,7 @@ class AreasExample: UIViewController {
         let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings))
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(view.bounds)
-        let chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
+        var chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
         chartSettings.trailing = 20
         chartSettings.labelsToAxisSpacingX = 20
         chartSettings.labelsToAxisSpacingY = 20

--- a/Examples/Examples/CoordsExample.swift
+++ b/Examples/Examples/CoordsExample.swift
@@ -27,7 +27,7 @@ class CoordsExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(view.bounds)
         
-        let chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
+        var chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
         chartSettings.trailing = 20
         chartSettings.labelsToAxisSpacingX = 15
         chartSettings.labelsToAxisSpacingY = 15

--- a/Examples/Examples/CustomUnitsExample.swift
+++ b/Examples/Examples/CustomUnitsExample.swift
@@ -79,7 +79,7 @@ class CustomUnitsExample: UIViewController {
         let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings))
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(view.bounds)
-        let chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
+        var chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
         chartSettings.trailing = 80
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)

--- a/Examples/Examples/EqualSpacingExample.swift
+++ b/Examples/Examples/EqualSpacingExample.swift
@@ -31,7 +31,7 @@ class EqualSpacingExample: UIViewController {
         let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings))
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(view.bounds)
-        let chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
+        var chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
         chartSettings.trailing = 40
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)

--- a/Examples/Examples/ExamplesDefaults.swift
+++ b/Examples/Examples/ExamplesDefaults.swift
@@ -28,7 +28,7 @@ struct ExamplesDefaults {
     }
     
     fileprivate static var iPadChartSettings: ChartSettings {
-        let chartSettings = ChartSettings()
+        var chartSettings = ChartSettings()
         chartSettings.leading = 20
         chartSettings.top = 20
         chartSettings.trailing = 20
@@ -44,7 +44,7 @@ struct ExamplesDefaults {
     }
     
     fileprivate static var iPhoneChartSettings: ChartSettings {
-        let chartSettings = ChartSettings()
+        var chartSettings = ChartSettings()
         chartSettings.leading = 10
         chartSettings.top = 10
         chartSettings.trailing = 10
@@ -60,14 +60,14 @@ struct ExamplesDefaults {
     }
 
     fileprivate static var iPadChartSettingsWithPanZoom: ChartSettings {
-        let chartSettings = iPadChartSettings
+        var chartSettings = iPadChartSettings
         chartSettings.zoomPan.panEnabled = true
         chartSettings.zoomPan.zoomEnabled = true
         return chartSettings
     }
 
     fileprivate static var iPhoneChartSettingsWithPanZoom: ChartSettings {
-        let chartSettings = iPhoneChartSettings
+        var chartSettings = iPhoneChartSettings
         chartSettings.zoomPan.panEnabled = true
         chartSettings.zoomPan.zoomEnabled = true
         return chartSettings

--- a/Examples/Examples/MultiTrackerExample.swift
+++ b/Examples/Examples/MultiTrackerExample.swift
@@ -81,7 +81,7 @@ class MultiTrackerExample: UIViewController, UIGestureRecognizerDelegate {
     // MARK: – Chart configuration
     
     fileprivate lazy private(set) var chartSettings: ChartSettings = {
-        let chartSettings = ChartSettings()
+        var chartSettings = ChartSettings()
         chartSettings.top = 12
         chartSettings.bottom = 0
         chartSettings.trailing = 8

--- a/Examples/Examples/MultipleLabelsExample.swift
+++ b/Examples/Examples/MultipleLabelsExample.swift
@@ -31,7 +31,7 @@ class MultipleLabelsExample: UIViewController {
         let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings))
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(view.bounds)
-        let chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
+        var chartSettings = ExamplesDefaults.chartSettingsWithPanZoom
         chartSettings.trailing = 20
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)

--- a/SwiftCharts/Chart.swift
+++ b/SwiftCharts/Chart.swift
@@ -132,8 +132,8 @@ open class Chart: Pannable, Zoomable {
     
     open var zoomPanSettings: ChartSettingsZoomPan {
         set {
-            settings.zoomPan = zoomPanSettings
-            configZoomPan(zoomPanSettings)
+            settings.zoomPan = newValue
+            configZoomPan(newValue)
         } get {
             return settings.zoomPan
         }

--- a/SwiftCharts/Chart.swift
+++ b/SwiftCharts/Chart.swift
@@ -9,60 +9,60 @@
 import UIKit
 
 /// ChartSettings allows configuration of the visual layout of a chart
-open class ChartSettings {
+public struct ChartSettings {
 
     /// Empty space in points added to the leading edge of the chart
-    open var leading: CGFloat = 0
+    public var leading: CGFloat = 0
 
     /// Empty space in points added to the top edge of the chart
-    open var top: CGFloat = 0
+    public var top: CGFloat = 0
 
     /// Empty space in points added to the trailing edge of the chart
-    open var trailing: CGFloat = 0
+    public var trailing: CGFloat = 0
 
     /// Empty space in points added to the bottom edge of the chart
-    open var bottom: CGFloat = 0
+    public var bottom: CGFloat = 0
 
     /// The spacing in points between axis labels when using multiple labels for each axis value. This is currently only supported with an X axis.
-    open var labelsSpacing: CGFloat = 5
+    public var labelsSpacing: CGFloat = 5
 
     /// The spacing in points between X axis labels and the X axis line
-    open var labelsToAxisSpacingX: CGFloat = 5
+    public var labelsToAxisSpacingX: CGFloat = 5
 
     /// The spacing in points between Y axis labels and the Y axis line
-    open var labelsToAxisSpacingY: CGFloat = 5
+    public var labelsToAxisSpacingY: CGFloat = 5
 
-    open var spacingBetweenAxesX: CGFloat = 15
+    public var spacingBetweenAxesX: CGFloat = 15
 
-    open var spacingBetweenAxesY: CGFloat = 15
+    public var spacingBetweenAxesY: CGFloat = 15
 
     /// The spacing in points between axis title labels and axis labels
-    open var axisTitleLabelsToLabelsSpacing: CGFloat = 5
+    public var axisTitleLabelsToLabelsSpacing: CGFloat = 5
 
     /// The stroke width in points of the axis lines
-    open var axisStrokeWidth: CGFloat = 1.0
+    public var axisStrokeWidth: CGFloat = 1.0
     
-    open var zoomPan = ChartSettingsZoomPan()
+    public var zoomPan = ChartSettingsZoomPan()
     
     public init() {}
 }
 
-open class ChartSettingsZoomPan {
-    open var panEnabled = false
+public struct ChartSettingsZoomPan {
+    public var panEnabled = false
     
-    open var zoomEnabled = false
+    public var zoomEnabled = false
 
-    open var minZoomX: CGFloat?
+    public var minZoomX: CGFloat?
     
-    open var minZoomY: CGFloat?
+    public var minZoomY: CGFloat?
     
-    open var maxZoomX: CGFloat?
+    public var maxZoomX: CGFloat?
     
-    open var maxZoomY: CGFloat?
+    public var maxZoomY: CGFloat?
     
-    open var gestureMode: ChartZoomPanGestureMode = .max
+    public var gestureMode: ChartZoomPanGestureMode = .max
     
-    open var elastic: Bool = false
+    public var elastic: Bool = false
 }
 
 public enum ChartZoomPanGestureMode {
@@ -128,7 +128,7 @@ open class Chart: Pannable, Zoomable {
         return settings.zoomPan.minZoomY
     }
     
-    fileprivate let settings: ChartSettings
+    fileprivate var settings: ChartSettings
     
     open var zoomPanSettings: ChartSettingsZoomPan {
         set {


### PR DESCRIPTION
This ensures that they have value semantics. With it being a `class`, any modification is **shared** amongst all users of the instance.

That means that all changes to `ExampleDefaults.chartSettingsWithPanZoom`, for example, were being propagated to every observer. Now a local copy is made.