### PR TITLE
ChartAxisValueStaticGenerator: added precondition

### DIFF
--- a/SwiftCharts/Axis/ChartAxisValueStaticGenerator.swift
+++ b/SwiftCharts/Axis/ChartAxisValueStaticGenerator.swift
@@ -95,6 +95,7 @@ public struct ChartAxisValuesStaticGenerator {
      - returns: An array of axis values
      */
     fileprivate static func generateAxisValuesWithChartPoints(_ first: Double, last lastPar: Double, minSegmentCount: Double, maxSegmentCount: Double, multiple: Double, axisValueGenerator: ChartAxisValueStaticGenerator, addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue] {
+        precondition(multiple > 0, "Invalid multiple: \(multiple)")
         
         guard lastPar >=~ first else {fatalError("Invalid range generating axis values")}
         


### PR DESCRIPTION
Without this, the division by 0 results in a crash later on, so better to catch this earily and tell the user what was wrong.