### PR TITLE
ChartPointsAreaLayer supports Gradient

### DIFF
--- a/Examples/Examples/AreasExample.swift
+++ b/Examples/Examples/AreasExample.swift
@@ -42,9 +42,9 @@ class AreasExample: UIViewController {
         let c3 = UIColor(red: 0.1, green: 0.9, blue: 0.1, alpha: 0.4)
         
         
-        let chartPointsLayer1 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints1, areaColor: c1, animDuration: 3, animDelay: 0, addContainerPoints: true)
-        let chartPointsLayer2 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints2, areaColor: c2, animDuration: 3, animDelay: 0, addContainerPoints: true)
-        let chartPointsLayer3 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints3, areaColor: c3, animDuration: 3, animDelay: 0, addContainerPoints: true)
+        let chartPointsLayer1 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints1, areaColors: [c1], animDuration: 3, animDelay: 0, addContainerPoints: true)
+        let chartPointsLayer2 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints2, areaColors: [c2], animDuration: 3, animDelay: 0, addContainerPoints: true)
+        let chartPointsLayer3 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints3, areaColors: [c3], animDuration: 3, animDelay: 0, addContainerPoints: true)
         
         let lineModel1 = ChartLineModel(chartPoints: chartPoints1, lineColor: UIColor.black, animDuration: 1, animDelay: 0)
         let lineModel2 = ChartLineModel(chartPoints: chartPoints2, lineColor: UIColor.black, animDuration: 1, animDelay: 0)

--- a/Examples/Examples/MultiTrackerExample.swift
+++ b/Examples/Examples/MultiTrackerExample.swift
@@ -225,7 +225,7 @@ class MultiTrackerExample: UIViewController, UIGestureRecognizerDelegate {
         let lineModel = ChartLineModel(chartPoints: IOBPoints, lineColor: UIColor.IOBTintColor, lineWidth: 2, animDuration: 0, animDelay: 0)
         let IOBLine = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, lineModels: [lineModel])
 
-        let IOBArea = ChartPointsAreaLayer(xAxis: xAxis, yAxis: yAxis, chartPoints: containerPoints, areaColor: UIColor.IOBTintColor.withAlphaComponent(0.5), animDuration: 0, animDelay: 0, addContainerPoints: false)
+        let IOBArea = ChartPointsAreaLayer(xAxis: xAxis, yAxis: yAxis, chartPoints: containerPoints, areaColors: [UIColor.IOBTintColor.withAlphaComponent(0.75), UIColor.clear], animDuration: 0, animDelay: 0, addContainerPoints: false)
 
         // Grid lines
         let gridLayer = ChartGuideLinesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, axis: .xAndY, settings: guideLinesLayerSettings)

--- a/SwiftCharts/Layers/ChartPointsAreaLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsAreaLayer.swift
@@ -10,20 +10,24 @@ import UIKit
 
 open class ChartPointsAreaLayer<T: ChartPoint>: ChartPointsLayer<T> {
     
-    fileprivate let areaColor: UIColor
+    fileprivate let areaColors: [UIColor]
     fileprivate let animDuration: Float
     fileprivate let animDelay: Float
     fileprivate let addContainerPoints: Bool
 
     fileprivate var areaViews: [UIView] = []
     
-    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], areaColor: UIColor, animDuration: Float, animDelay: Float, addContainerPoints: Bool) {
-        self.areaColor = areaColor
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], areaColors: [UIColor], animDuration: Float, animDelay: Float, addContainerPoints: Bool) {
+        self.areaColors = areaColors
         self.animDuration = animDuration
         self.animDelay = animDelay
         self.addContainerPoints = addContainerPoints
         
         super.init(xAxis: xAxis, yAxis: yAxis, chartPoints: chartPoints)
+    }
+    
+    public convenience init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], areaColor: UIColor, animDuration: Float, animDelay: Float, addContainerPoints: Bool) {
+        self.init(xAxis: xAxis, yAxis: yAxis, chartPoints: chartPoints, areaColors: [areaColor], animDuration: animDuration, animDelay: animDelay, addContainerPoints: addContainerPoints)
     }
     
     open override func display(chart: Chart) {
@@ -39,7 +43,7 @@ open class ChartPointsAreaLayer<T: ChartPoint>: ChartPointsLayer<T> {
             points.append(CGPoint(x: origin.x, y: bottomY))
         }
         
-        let areaView = ChartAreasView(points: points, frame: chart.bounds, color: areaColor, animDuration: animDuration, animDelay: animDelay)
+        let areaView = ChartAreasView(points: points, frame: chart.bounds, colors: areaColors, animDuration: animDuration, animDelay: animDelay)
         areaViews.append(areaView)
         chart.addSubview(areaView)
     }


### PR DESCRIPTION
ChartPointsAreaLayer now takes in an array of UIColors. If you pass one color in the array, the layer will just display that color. If you pass more than one color, the layer will display a gradient. In this case, the first color passed will be first color at the top of the gradient. The last color passed will be the last color at the bottom of gradient. 

To allow for full control of the visible gradient, the gradient will start at the highest pint of the visible line and end at the bottom of the visible chart. This turned out to be a challenge because the UIBezierPath generates weird bounds values. However, I was able to understand it enough to come up with the solution. It works perfectly in the AreasExample and MultiTrackerExample. Not sure how it will hold up in other cases.

I think we can also add a top-down animation option. But I think it's a good start. This is my second pull request!