### PR TITLE
Highlight Completion Handler

### DIFF
--- a/Examples/Examples/MultiTrackerExample.swift
+++ b/Examples/Examples/MultiTrackerExample.swift
@@ -181,7 +181,8 @@ class MultiTrackerExample: UIViewController, UIGestureRecognizerDelegate {
             chartPoints: allPoints,
             tintColor: UIColor.glucoseTintColor,
             labelCenterY: chartSettings.top,
-            gestureRecognizer: chartLongPressGestureRecognizer
+            gestureRecognizer: chartLongPressGestureRecognizer,
+            onCompleteHighlight: nil
         )
 
         let layers: [ChartLayer?] = [
@@ -247,7 +248,8 @@ class MultiTrackerExample: UIViewController, UIGestureRecognizerDelegate {
             chartPoints: IOBPoints,
             tintColor: UIColor.IOBTintColor,
             labelCenterY: chartSettings.top,
-            gestureRecognizer: chartLongPressGestureRecognizer
+            gestureRecognizer: chartLongPressGestureRecognizer,
+            onCompleteHighlight: nil
         )
 
         let layers: [ChartLayer?] = [
@@ -276,9 +278,10 @@ private extension ChartPointsTouchHighlightLayer {
         chartPoints: [T],
         tintColor: UIColor,
         labelCenterY: CGFloat = 0,
-        gestureRecognizer: UILongPressGestureRecognizer? = nil
+        gestureRecognizer: UILongPressGestureRecognizer? = nil,
+        onCompleteHighlight: (()->Void)? = nil
     ) {
-        self.init(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints, gestureRecognizer: gestureRecognizer,
+        self.init(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints, gestureRecognizer: gestureRecognizer, onCompleteHighlight: onCompleteHighlight,
                   modelFilter: { (screenLoc, chartPointModels) -> ChartPointLayerModel<T>? in
                     if let index = chartPointModels.map({ $0.screenLoc.x }).findClosestElementIndexToValue(screenLoc.x) {
                         return chartPointModels[index]

--- a/SwiftCharts/Axis/ChartAxis.swift
+++ b/SwiftCharts/Axis/ChartAxis.swift
@@ -135,6 +135,10 @@ open class ChartAxis: CustomStringConvertible {
         fatalError("Override")
     }
     
+    open var transform: (scale: CGFloat, translation: CGFloat) {
+        return (scale: CGFloat(zoomFactor), translation: firstScreenInit - firstScreen)
+    }
+    
     func offsetFirstScreen(_ offset: CGFloat) {
         firstScreen += offset
         firstScreenInit += offset

--- a/SwiftCharts/Axis/ChartAxis.swift
+++ b/SwiftCharts/Axis/ChartAxis.swift
@@ -41,6 +41,7 @@ open class ChartAxis: CustomStringConvertible {
     }
     
     open var zoomFactor: Double {
+        guard visibleLength != 0 else {return 1}
         return abs(length / visibleLength)
     }
     

--- a/SwiftCharts/Axis/ChartAxisModel.swift
+++ b/SwiftCharts/Axis/ChartAxisModel.swift
@@ -61,11 +61,8 @@ open class ChartAxisModel {
         var scalars: [Double] = []
         var dict = [Double: [ChartAxisLabel]]()
         for axisValue in axisValues {
-            if !axisValue.hidden {
-                scalars.append(axisValue.scalar)
-                dict[axisValue.scalar] = axisValue.labels
-            }
-
+            scalars.append(axisValue.scalar)
+            dict[axisValue.scalar] = axisValue.labels
         }
         let (firstModelValue, lastModelValue) = (axisValues.first!.scalar, axisValues.last!.scalar)
         

--- a/SwiftCharts/Chart.swift
+++ b/SwiftCharts/Chart.swift
@@ -133,6 +133,11 @@ open class Chart: Pannable, Zoomable {
         return settings.zoomPan.minZoomY
     }
     
+    /// Max possible total pan distance with current transformation
+    open var currentMaxPan: CGFloat {
+        return contentView.frame.height - containerView.frame.height
+    }
+    
     fileprivate var settings: ChartSettings
     
     open var zoomPanSettings: ChartSettingsZoomPan {

--- a/SwiftCharts/Chart.swift
+++ b/SwiftCharts/Chart.swift
@@ -247,8 +247,13 @@ open class Chart: Pannable, Zoomable {
         return view.frame
     }
 
-    open var containerFrame: CGRect {
+    var containerFrame: CGRect {
         return containerView.frame
+    }
+    
+    // Implementation details free variable name & backwards compatibility
+    open var innerFrame: CGRect {
+        return containerFrame
     }
     
     open var contentFrame: CGRect {

--- a/SwiftCharts/Layers/ChartDividersLayer.swift
+++ b/SwiftCharts/Layers/ChartDividersLayer.swift
@@ -11,14 +11,16 @@ import UIKit
 public struct ChartDividersLayerSettings {
     let linesColor: UIColor
     let linesWidth: CGFloat
-    let start: CGFloat // points from start to axis, axis is 0
-    let end: CGFloat // points from axis to end, axis is 0
+    let start: CGFloat // Points from start to axis, axis is 0
+    let end: CGFloat // Points from axis to end, axis is 0
+    let show: ((Double) -> Bool)? // Set visibility of individual axis values. If nil, all axis values will be shown.
     
-    public init(linesColor: UIColor = UIColor.gray, linesWidth: CGFloat = 0.3, start: CGFloat = 5, end: CGFloat = 5) {
+    public init(linesColor: UIColor = UIColor.gray, linesWidth: CGFloat = 0.3, start: CGFloat = 5, end: CGFloat = 5, show: ((Double) -> Bool)? = nil) {
         self.linesColor = linesColor
         self.linesWidth = linesWidth
         self.start = start
         self.end = end
+        self.show = show
     }
 }
 
@@ -50,11 +52,15 @@ open class ChartDividersLayer: ChartCoordsSpaceLayer {
     }
     
     override open func chartViewDrawing(context: CGContext, chart: Chart) {
-        let xScreenLocs = xAxisLayer.axisValuesScreenLocs
-        let yScreenLocs = yAxisLayer.axisValuesScreenLocs
+        let xValues = xAxisLayer.currentAxisValues
+        let yValues = yAxisLayer.currentAxisValues
         
         if axis == .x || axis == .xAndY {
-            for xScreenLoc in xScreenLocs {
+            for xValue in xValues {
+                guard (settings.show?(xValue) ?? true) else {continue}
+                
+                let xScreenLoc = xAxisLayer.axis.screenLocForScalar(xValue)
+                
                 let x1 = xScreenLoc
                 let y1 = xAxisLayer.lineP1.y + (xAxisLayer.low ? -settings.end : settings.end)
                 let x2 = xScreenLoc
@@ -64,7 +70,11 @@ open class ChartDividersLayer: ChartCoordsSpaceLayer {
         }
         
         if axis == .y || axis == .xAndY {
-            for yScreenLoc in yScreenLocs {
+            for yValue in yValues {
+                guard (settings.show?(yValue) ?? true) else {continue}
+                
+                let yScreenLoc = yAxisLayer.axis.screenLocForScalar(yValue)
+                
                 let x1 = yAxisLayer.lineP1.x + (yAxisLayer.low ? -settings.start : settings.start)
                 let y1 = yScreenLoc
                 let x2 = yAxisLayer.lineP1.x + (yAxisLayer.low ? settings.end : settings.end)

--- a/SwiftCharts/Layers/ChartPointsTouchHighlightLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsTouchHighlightLayer.swift
@@ -18,13 +18,16 @@ open class ChartPointsTouchHighlightLayer<T: ChartPoint, U: UIView>: ChartPoints
     fileprivate let chartPointLayerModelForScreenLocFilter: ChartPointLayerModelForScreenLocFilter
 
     open let longPressGestureRecognizer: UILongPressGestureRecognizer
+    
+    open var onCompleteHighlight: (()->Void)?
 
     /// The delay after touches end before the highlighted point fades out. Set to `nil` to keep the highlight until the next touch.
     open var hideDelay: TimeInterval? = 1.0
 
-    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], gestureRecognizer: UILongPressGestureRecognizer? = nil, modelFilter: @escaping ChartPointLayerModelForScreenLocFilter, viewGenerator: @escaping ChartPointViewGenerator) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], gestureRecognizer: UILongPressGestureRecognizer? = nil, onCompleteHighlight: (()->Void)? = nil, modelFilter: @escaping ChartPointLayerModelForScreenLocFilter, viewGenerator: @escaping ChartPointViewGenerator) {
         chartPointLayerModelForScreenLocFilter = modelFilter
         longPressGestureRecognizer = gestureRecognizer ?? UILongPressGestureRecognizer()
+        self.onCompleteHighlight = onCompleteHighlight
 
         super.init(xAxis: xAxis, yAxis: yAxis, chartPoints: chartPoints, viewGenerator: viewGenerator)
     }
@@ -94,6 +97,7 @@ open class ChartPointsTouchHighlightLayer<T: ChartPoint, U: UIView>: ChartPoints
                     }, completion: {completed in
                         if completed {
                             self.highlightedModel = nil
+                            self.onCompleteHighlight?()
                         }
                     }
                 )


### PR DESCRIPTION
Having an optional completion handler for the TouchHighlight fade animation should come in handy. If there are elements that change when a user starts panning, this will allow us to revert back to the original state. For example, you can have two fixed UILabels at the top of the view that correspond to a charts below it. They are initially set to the last X and Y values of the chart. As the user pans these values change. With this completion handler, the UILabels can switch back to the original values when user stops the pan (after the fade animation). This is just one example but I'm sure it can be useful. Let me know if you would like to change the naming convention.

FYI: I fixed up my other pull request and left a comment. Thanks!