### PR TITLE
ChartPointViewBarStacked: allowing only rounding some corners

### DIFF
--- a/SwiftCharts/Views/ChartPointViewBar.swift
+++ b/SwiftCharts/Views/ChartPointViewBar.swift
@@ -16,22 +16,34 @@ public struct ChartBarViewSettings {
     let selectionViewUpdater: ChartViewSelector?
     
     let cornerRadius: CGFloat
+    let roundedCorners: UIRectCorner
     
     let delayInit: Bool
     
-    public init(animDuration: Float = 0.5, animDelay: Float = 0, cornerRadius: CGFloat = 0, selectionViewUpdater: ChartViewSelector? = nil, delayInit: Bool = false) {
+    public init(animDuration: Float = 0.5,
+                animDelay: Float = 0,
+                cornerRadius: CGFloat = 0,
+                roundedCorners: UIRectCorner = .allCorners,
+                selectionViewUpdater: ChartViewSelector? = nil,
+                delayInit: Bool = false) {
         self.animDuration = animDuration
         self.animDelay = animDelay
         self.cornerRadius = cornerRadius
+        self.roundedCorners = roundedCorners
         self.selectionViewUpdater = selectionViewUpdater
         self.delayInit = delayInit
     }
     
-    public func copy(animDuration: Float? = nil, animDelay: Float? = nil, cornerRadius: CGFloat? = nil, selectionViewUpdater: ChartViewSelector? = nil) -> ChartBarViewSettings {
+    public func copy(animDuration: Float? = nil,
+                     animDelay: Float? = nil,
+                     cornerRadius: CGFloat? = nil,
+                     roundedCorners: UIRectCorner? = nil,
+                     selectionViewUpdater: ChartViewSelector? = nil) -> ChartBarViewSettings {
         return ChartBarViewSettings(
             animDuration: animDuration ?? self.animDuration,
             animDelay: animDelay ?? self.animDelay,
             cornerRadius: cornerRadius ?? self.cornerRadius,
+            roundedCorners: roundedCorners ?? self.roundedCorners,
             selectionViewUpdater: selectionViewUpdater ?? self.selectionViewUpdater
         )
     }

--- a/SwiftCharts/Views/ChartPointViewBarStacked.swift
+++ b/SwiftCharts/Views/ChartPointViewBarStacked.swift
@@ -67,7 +67,7 @@ open class ChartPointViewBarStacked: ChartPointViewBar {
                 let corners: UIRectCorner
                 
                 if (stackFrames.count == 1) {
-                    corners = UIRectCorner.allCorners
+                    corners = settings.roundedCorners
                 } else {
                     switch (index, isHorizontal) {
                     case (0, true):
@@ -87,7 +87,7 @@ open class ChartPointViewBarStacked: ChartPointViewBar {
                 
                 let path = UIBezierPath(
                     roundedRect: bounds,
-                    byRoundingCorners: corners,
+                    byRoundingCorners: corners.intersection(settings.roundedCorners),
                     cornerRadii: CGSize(width: settings.cornerRadius, height: settings.cornerRadius)
                 )
                 


### PR DESCRIPTION
Example:
```swift
ChartBarViewSettings(
                cornerRadius: barWidth / 2.0,
                roundedCorners: [.topLeft, .topRight]
            )
```

<img width="111" alt="screen shot 2017-03-23 at 3 21 29 pm" src="https://cloud.githubusercontent.com/assets/685609/24272851/660aa312-0fdc-11e7-94f1-be472f2d6709.png">