### PR TITLE
Optional completion handler for TouchHighlight fade animation

### DIFF
--- a/Examples/Examples/MultiTrackerExample.swift
+++ b/Examples/Examples/MultiTrackerExample.swift
@@ -181,7 +181,8 @@ class MultiTrackerExample: UIViewController, UIGestureRecognizerDelegate {
             chartPoints: allPoints,
             tintColor: UIColor.glucoseTintColor,
             labelCenterY: chartSettings.top,
-            gestureRecognizer: chartLongPressGestureRecognizer
+            gestureRecognizer: chartLongPressGestureRecognizer,
+            onCompleteHighlight: nil
         )
 
         let layers: [ChartLayer?] = [
@@ -247,7 +248,8 @@ class MultiTrackerExample: UIViewController, UIGestureRecognizerDelegate {
             chartPoints: IOBPoints,
             tintColor: UIColor.IOBTintColor,
             labelCenterY: chartSettings.top,
-            gestureRecognizer: chartLongPressGestureRecognizer
+            gestureRecognizer: chartLongPressGestureRecognizer,
+            onCompleteHighlight: nil
         )
 
         let layers: [ChartLayer?] = [
@@ -276,9 +278,10 @@ private extension ChartPointsTouchHighlightLayer {
         chartPoints: [T],
         tintColor: UIColor,
         labelCenterY: CGFloat = 0,
-        gestureRecognizer: UILongPressGestureRecognizer? = nil
+        gestureRecognizer: UILongPressGestureRecognizer? = nil,
+        onCompleteHighlight: (()->Void)? = nil
     ) {
-        self.init(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints, gestureRecognizer: gestureRecognizer,
+        self.init(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints, gestureRecognizer: gestureRecognizer, onCompleteHighlight: onCompleteHighlight,
                   modelFilter: { (screenLoc, chartPointModels) -> ChartPointLayerModel<T>? in
                     if let index = chartPointModels.map({ $0.screenLoc.x }).findClosestElementIndexToValue(screenLoc.x) {
                         return chartPointModels[index]

--- a/SwiftCharts/Layers/ChartPointsTouchHighlightLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsTouchHighlightLayer.swift
@@ -18,13 +18,16 @@ open class ChartPointsTouchHighlightLayer<T: ChartPoint, U: UIView>: ChartPoints
     fileprivate let chartPointLayerModelForScreenLocFilter: ChartPointLayerModelForScreenLocFilter
 
     open let longPressGestureRecognizer: UILongPressGestureRecognizer
+    
+    open var onCompleteHighlight: (()->Void)?
 
     /// The delay after touches end before the highlighted point fades out. Set to `nil` to keep the highlight until the next touch.
     open var hideDelay: TimeInterval? = 1.0
 
-    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], gestureRecognizer: UILongPressGestureRecognizer? = nil, modelFilter: @escaping ChartPointLayerModelForScreenLocFilter, viewGenerator: @escaping ChartPointViewGenerator) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], gestureRecognizer: UILongPressGestureRecognizer? = nil, onCompleteHighlight: (()->Void)? = nil, modelFilter: @escaping ChartPointLayerModelForScreenLocFilter, viewGenerator: @escaping ChartPointViewGenerator) {
         chartPointLayerModelForScreenLocFilter = modelFilter
         longPressGestureRecognizer = gestureRecognizer ?? UILongPressGestureRecognizer()
+        self.onCompleteHighlight = onCompleteHighlight
 
         super.init(xAxis: xAxis, yAxis: yAxis, chartPoints: chartPoints, viewGenerator: viewGenerator)
     }
@@ -94,6 +97,7 @@ open class ChartPointsTouchHighlightLayer<T: ChartPoint, U: UIView>: ChartPoints
                     }, completion: {completed in
                         if completed {
                             self.highlightedModel = nil
+                            self.onCompleteHighlight?()
                         }
                     }
                 )


### PR DESCRIPTION
This was submitted previously, however there were issues when squashing. This was the previous description:
Having an optional completion handler for the TouchHighlight fade animation should come in handy. For example, if there are elements that change when a user starts panning, this will allow us to revert back to the original state. For example, you can have two fixed UILabels at the top of the view that correspond to a charts below it. They are initially set to the last X and Y values of the chart. As the user pans these values change. With this completion handler, the UILabels can switch back to the original values when user stops the pan (after the fade animation). This is just one example but I'm sure it can be useful. Let me know if you would like to change the naming convention.

Changed naming convention and other minor formatting/convention improvements.