### PR TITLE
Less restrictive access levels to allow subclass label drawer

### DIFF
--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -60,10 +60,8 @@ public enum ChartLabelDrawerRotationKeep {
 
 open class ChartLabelDrawer: ChartContextDrawer {
     
-    var screenLoc: CGPoint
-    
-    fileprivate var transform: CGAffineTransform?
-    
+    open var screenLoc: CGPoint
+    open var transform: CGAffineTransform?    
     open let label: ChartAxisLabel
     
     open var center: CGPoint {
@@ -78,7 +76,7 @@ open class ChartLabelDrawer: ChartContextDrawer {
         return CGRect(x: screenLoc.x, y: screenLoc.y, width: size.width, height: size.height)
     }
     
-    init(label: ChartAxisLabel, screenLoc: CGPoint) {
+    public init(label: ChartAxisLabel, screenLoc: CGPoint) {
         self.label = label
         self.screenLoc = screenLoc
         
@@ -87,7 +85,7 @@ open class ChartLabelDrawer: ChartContextDrawer {
         self.transform = self.transform(screenLoc, settings: label.settings)
     }
 
-    override func draw(context: CGContext, chart: Chart) {
+    override open func draw(context: CGContext, chart: Chart) {
         let labelSize = size
         
         let labelX = screenLoc.x

--- a/SwiftCharts/Layers/ChartGuideLinesLayer.swift
+++ b/SwiftCharts/Layers/ChartGuideLinesLayer.swift
@@ -9,8 +9,8 @@
 import UIKit
 
 open class ChartGuideLinesLayerSettings {
-    let linesColor: UIColor
-    let linesWidth: CGFloat
+    public let linesColor: UIColor
+    public let linesWidth: CGFloat
     
     public init(linesColor: UIColor = UIColor.gray, linesWidth: CGFloat = 0.3) {
         self.linesColor = linesColor
@@ -19,8 +19,8 @@ open class ChartGuideLinesLayerSettings {
 }
 
 open class ChartGuideLinesDottedLayerSettings: ChartGuideLinesLayerSettings {
-    let dotWidth: CGFloat
-    let dotSpacing: CGFloat
+    public let dotWidth: CGFloat
+    public let dotSpacing: CGFloat
     
     public init(linesColor: UIColor, linesWidth: CGFloat, dotWidth: CGFloat = 2, dotSpacing: CGFloat = 2) {
         self.dotWidth = dotWidth

--- a/SwiftCharts/Layers/ChartPointsLineLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLineLayer.swift
@@ -13,7 +13,7 @@ public enum LineJoin {
     case round
     case bevel
     
-    var CALayerString: String {
+    public var CALayerString: String {
         switch self {
         case .miter: return kCALineJoinMiter
         case .round: return kCALineCapRound
@@ -21,7 +21,7 @@ public enum LineJoin {
         }
     }
     
-    var CGValue: CGLineJoin {
+    public var CGValue: CGLineJoin {
         switch self {
         case .miter: return .miter
         case .round: return .round
@@ -35,7 +35,7 @@ public enum LineCap {
     case round
     case square
     
-    var CALayerString: String {
+    public var CALayerString: String {
         switch self {
         case .butt: return kCALineCapButt
         case .round: return kCALineCapRound
@@ -43,7 +43,7 @@ public enum LineCap {
         }
     }
     
-    var CGValue: CGLineCap {
+    public var CGValue: CGLineCap {
         switch self {
         case .butt: return .butt
         case .round: return .round
@@ -82,9 +82,8 @@ open class ChartPointsLineLayer<T: ChartPoint>: ChartPointsLayer<T> {
     open let pathGenerator: ChartLinesViewPathGenerator
     open fileprivate(set) var screenLines: [(screenLine: ScreenLine<T>, view: ChartLinesView)] = []
     
-    fileprivate let useView: Bool
-    
-    fileprivate let delayInit: Bool
+    public let useView: Bool
+    public let delayInit: Bool
     
     fileprivate var isInTransform = false
     

--- a/SwiftCharts/Layers/ChartPointsViewsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsViewsLayer.swift
@@ -31,7 +31,7 @@ open class ChartPointsViewsLayer<T: ChartPoint, U: UIView>: ChartPointsLayer<T> 
     // TODO z ordering
     fileprivate let keepOnFront: Bool
     
-    fileprivate let delayInit: Bool
+    public let delayInit: Bool
     
     public var customTransformer: ((ChartPointLayerModel<T>, UIView, ChartPointsViewsLayer<T, U>) -> Void)?
     


### PR DESCRIPTION
Hi,
From time-to-time it's needed to draw something more complex instead of text labels along the axis, and the only way to do it it now is to subclass `ChartLabelDrawer`, as I see it. But to make it possible we have to make access levels to some key functions and properties less restrictive.
Also, it's useful to open some properties of layers related to delayed init to check if it's enabled externally.
Thanks in advance.