### PR TITLE
Replaced calculation of label text size with access to cached value

### DIFF
--- a/SwiftCharts/Axis/ChartAxisLabel.swift
+++ b/SwiftCharts/Axis/ChartAxisLabel.swift
@@ -20,9 +20,13 @@ open class ChartAxisLabel {
     
     var hidden: Bool = false
 
+    open lazy private(set) var textSizeNonRotated: CGSize = {
+        return self.text.size(self.settings.font)
+    }()
+    
     /// The size of the bounding rectangle for the axis label, taking into account the font and rotation it will be drawn with
     open lazy private(set) var textSize: CGSize = {
-        let size = self.text.size(self.settings.font)
+        let size = self.textSizeNonRotated
         if self.settings.rotation =~ 0 {
             return size
         } else {

--- a/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
@@ -110,7 +110,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
             
             let rowY = calculateRowY(rowHeights: rowHeights, rowIndex: index, spacing: spacingLabelBetweenAxis)
             
-            let labelWidth = label.text.width(label.settings.font)
+            let labelWidth = label.textSizeNonRotated.width
             let x = (axis.lastScreenInit - axis.firstScreenInit) / 2 + axis.firstScreenInit - labelWidth / 2
             let y = self.offset + offset + rowY
             
@@ -163,7 +163,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
                 let x = axis.screenLocForScalar(scalar)
                 let y = self.offset + offset + rowY
                 
-                let labelSize = label.text.size(label.settings.font)
+                let labelSize = label.textSizeNonRotated
                 let labelX = x - (labelSize.width / 2)
                 
                 let labelDrawer = ChartLabelDrawer(label: label, screenLoc: CGPoint(x: labelX, y: y))

--- a/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
@@ -98,7 +98,7 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
                 print("WARNING: No support for multiple definition labels on vertical axis. Using only first one.")
             }
             let axisLabel = firstTitleLabel
-            let labelSize = axisLabel.text.size(axisLabel.settings.font)
+            let labelSize = axisLabel.textSizeNonRotated
             let axisLabelDrawer = ChartLabelDrawer(label: axisLabel, screenLoc: CGPoint(
                 x: self.offset + offset,
                 y: axis.lastScreenInit + ((axis.firstScreenInit - axis.lastScreenInit) / 2) - (labelSize.height / 2)))
@@ -120,7 +120,7 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
             let labels = labelsGenerator.generate(scalar, axis: axis)
             let y = axis.screenLocForScalar(scalar)
             if let axisLabel = labels.first { // for now y axis supports only one label x value
-                let labelSize = axisLabel.text.size(axisLabel.settings.font)
+                let labelSize = axisLabel.textSizeNonRotated
                 let labelY = y - (labelSize.height / 2)
                 let labelX = labelsX(offset: offset, labelWidth: labelSize.width, textAlignment: axisLabel.settings.textAlignment)
                 let labelDrawer = ChartLabelDrawer(label: axisLabel, screenLoc: CGPoint(x: labelX, y: labelY))
@@ -138,7 +138,7 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
     
     fileprivate func maxLabelWidth(_ axisLabels: [ChartAxisLabel]) -> CGFloat {
         return axisLabels.reduce(CGFloat(0)) {maxWidth, label in
-            return max(maxWidth, label.text.width(label.settings.font))
+            return max(maxWidth, label.textSizeNonRotated.width)
         }
     }
     fileprivate func maxLabelWidth(_ axisValues: [Double]) -> CGFloat {

--- a/SwiftCharts/ChartAxisValueArray.swift
+++ b/SwiftCharts/ChartAxisValueArray.swift
@@ -13,7 +13,7 @@ extension Array where Element: ChartAxisValue {
     func calculateLabelsDimensions() -> (total: CGSize, max: CGSize) {
         return flatMap({
             guard let label = $0.labels.first else {return nil}
-            return label.text.size(label.settings.font)
+            return label.textSizeNonRotated
         }).reduce((total: CGSize.zero, max: CGSize.zero), {(lhs: (total: CGSize, max: CGSize), rhs: CGSize) in
             return (
                 CGSize(width: lhs.total.width + rhs.width, height: lhs.total.height + rhs.height),

--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -71,7 +71,7 @@ open class ChartLabelDrawer: ChartContextDrawer {
     }
     
     open var size: CGSize {
-        return label.text.size(label.settings.font)
+        return label.textSizeNonRotated
     }
     
     open var frame: CGRect {


### PR DESCRIPTION
Hi,
Because chart axis label is immutable structure we can store size of non-rotated text and use the value  instead of dynamic calculation. It's supposed to improve performance especially in case of scrolling.
