### PR TITLE
No need for a straight line to close() the path.

### DIFF
--- a/SwiftCharts/Views/StraightLinePathGenerator.swift
+++ b/SwiftCharts/Views/StraightLinePathGenerator.swift
@@ -29,8 +29,6 @@ open class StraightLinePathGenerator: ChartLinesViewPathGenerator {
                 progressline.move(to: p1)
                 progressline.addLine(to: p2)
             }
-
-            progressline.close()
         }
 
         return progressline


### PR DESCRIPTION
This behavior was causing a Path of straight lines to "close" its path. For example, a Path with points `(0, 2), (0, 7), (0, 5), (0, 1), (0, 4)` was finishing in `(0, 1)` instead of `(0, 4)`. For solid lines no one could see, but for dashed lines you could see that between the last 2 points, the dashed line was duplicated.