### PR TITLE
Fixed 2 leaks setting stackedTapHandler

### DIFF
--- a/SwiftCharts/Layers/ChartGroupedBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartGroupedBarsLayer.swift
@@ -256,7 +256,7 @@ open class ChartGroupedStackedBarsLayer_<N>: ChartGroupedBarsLayer<ChartStackedB
     }
     
     override func configBarView(_ group: ChartPointsBarGroup<ChartStackedBarModel>, groupIndex: Int, barIndex: Int, bar: ChartStackedBarModel, barView: ChartPointViewBarStacked) {
-        barView.stackedTapHandler = {[weak self] tappedStackedBar in guard let weakSelf = self else {return}
+        barView.stackedTapHandler = {[weak self, unowned barView] tappedStackedBar in guard let weakSelf = self else {return}
             
             let stackFrameData = tappedStackedBar.stackFrame.map{stackFrame in
                 ChartTappedBarStackedFrame(stackedItemModel: bar.items[stackFrame.index], stackedItemView: stackFrame.view, stackedItemViewFrameRelativeToBarParent: stackFrame.viewFrameRelativeToBarSuperview, stackedItemIndex: stackFrame.index)

--- a/SwiftCharts/Layers/ChartStackedBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartStackedBarsLayer.swift
@@ -153,7 +153,7 @@ open class ChartStackedBarsLayer<T: ChartPointViewBarStacked>: ChartCoordsSpaceL
         for (index, barModel) in barModels.enumerated() {
             let barView = barsGenerator.generateView(barModel, settings: settings, model: barModel, index: index, groupIndex: 0, chart: chart)
             barView.stackFrameSelectionViewUpdater = stackFrameSelectionViewUpdater
-            barView.stackedTapHandler = {[weak self] tappedStackedBar in guard let weakSelf = self else {return}
+            barView.stackedTapHandler = {[weak self, unowned barView] tappedStackedBar in guard let weakSelf = self else {return}
                 
                 let stackFrameData = tappedStackedBar.stackFrame.map{stackFrame in
                     ChartTappedBarStackedFrame(stackedItemModel: barModel.items[stackFrame.index], stackedItemView: stackFrame.view, stackedItemViewFrameRelativeToBarParent: stackFrame.viewFrameRelativeToBarSuperview, stackedItemIndex: stackFrame.index)


### PR DESCRIPTION
`ChartPointViewBarStacked` owns `stackedTapHandler`, so the handler must not reference its parent. This currently creates a cycle.
This is why it's important to reason about memory ownership instead of just blindly making `self` `weak` everywhere. There's nothing special about `self` that can lead to cycles, **anything** can lead to a cycle.