### PR TITLE
Make candle stick fill colours configurable

### DIFF
--- a/Examples/Examples/CandleStickExample.swift
+++ b/Examples/Examples/CandleStickExample.swift
@@ -105,7 +105,7 @@ class CandleStickExample: UIViewController {
         let coordsSpace = ChartCoordsSpaceRightBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let chartPointsLineLayer = ChartCandleStickLayer<ChartPointCandleStick>(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints, itemWidth: Env.iPad ? 10 : 5, strokeWidth: Env.iPad ? 1 : 0.6)
+        let chartPointsLineLayer = ChartCandleStickLayer<ChartPointCandleStick>(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: chartPoints, itemWidth: Env.iPad ? 10 : 5, strokeWidth: Env.iPad ? 1 : 0.6, increasingColor: UIColor.green, decreasingColor: UIColor.red)
         
         let settings = ChartGuideLinesLayerSettings(linesColor: UIColor.black, linesWidth: ExamplesDefaults.guidelinesWidth)
         let guidelinesLayer = ChartGuideLinesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, settings: settings)

--- a/SwiftCharts/Layers/ChartCandleStickLayer.swift
+++ b/SwiftCharts/Layers/ChartCandleStickLayer.swift
@@ -15,10 +15,14 @@ open class ChartCandleStickLayer<T: ChartPointCandleStick>: ChartPointsLayer<T> 
 
     fileprivate let itemWidth: CGFloat
     fileprivate let strokeWidth: CGFloat
+    fileprivate let increasingColor: UIColor
+    fileprivate let decreasingColor: UIColor
     
-    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], itemWidth: CGFloat = 10, strokeWidth: CGFloat = 1) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, chartPoints: [T], itemWidth: CGFloat = 10, strokeWidth: CGFloat = 1, increasingColor: UIColor = UIColor.black, decreasingColor: UIColor = UIColor.white) {
         self.itemWidth = itemWidth
         self.strokeWidth = strokeWidth
+        self.increasingColor = increasingColor
+        self.decreasingColor = decreasingColor
         
         super.init(xAxis: xAxis, yAxis: yAxis, chartPoints: chartPoints)
     }
@@ -30,9 +34,7 @@ open class ChartCandleStickLayer<T: ChartPointCandleStick>: ChartPointsLayer<T> 
     }
     
     override open func chartContentViewDrawing(context: CGContext, chart: Chart) {
-        
         for screenItem in screenItems {
-            
             context.setLineWidth(strokeWidth)
             context.setStrokeColor(UIColor.black.cgColor)
             context.move(to: CGPoint(x: screenItem.x, y: screenItem.lineTop))
@@ -58,7 +60,7 @@ open class ChartCandleStickLayer<T: ChartPointCandleStick>: ChartPointsLayer<T> 
             let openScreenY = modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.open)).y
             let closeScreenY = modelLocToScreenLoc(x: Double(x), y: Double(chartPoint.close)).y
             
-            let (rectTop, rectBottom, fillColor) = closeScreenY < openScreenY ? (closeScreenY, openScreenY, UIColor.white) : (openScreenY, closeScreenY, UIColor.black)
+            let (rectTop, rectBottom, fillColor) = closeScreenY < openScreenY ? (closeScreenY, openScreenY, self.increasingColor) : (openScreenY, closeScreenY, self.decreasingColor)
             return CandleStickScreenItem(x: x, lineTop: highScreenY, lineBottom: lowScreenY, rectTop: rectTop, rectBottom: rectBottom, width: itemWidth, fillColor: fillColor)
         }
     }


### PR DESCRIPTION
Default colours for candle sticks are hardcoded as black and white in `ChartCandleStickLayer`. 
This PR allows to configure the fill colours via (optional) constructor parameters.