### PR TITLE
Ran Swift syntax updater to bring syntax up to Swift 4.2

### DIFF
--- a/SwiftCharts.xcodeproj/project.pbxproj
+++ b/SwiftCharts.xcodeproj/project.pbxproj
@@ -984,7 +984,7 @@
 					};
 					06405DA51B8AA74700A689FF = {
 						CreatedOnToolsVersion = 6.4;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 					};
 					22E7020E1BF5B8EC00C19675 = {
 						CreatedOnToolsVersion = 7.1.1;
@@ -1537,7 +1537,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1558,7 +1558,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schuetz.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -167,7 +167,7 @@ open class ChartLabelDrawer: ChartContextDrawer {
     
     fileprivate func drawLabel(x: CGFloat, y: CGFloat, text: String) {
         #if swift(>=4)
-        let attributes = [NSAttributedStringKey.font: label.settings.font, NSAttributedStringKey.foregroundColor: label.settings.fontColor]
+        let attributes = [NSAttributedString.Key.font: label.settings.font, NSAttributedString.Key.foregroundColor: label.settings.fontColor]
         #else
         let attributes = [NSFontAttributeName: label.settings.font, NSForegroundColorAttributeName: label.settings.fontColor]
         #endif

--- a/SwiftCharts/Layers/ChartPointsLineLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLineLayer.swift
@@ -15,9 +15,9 @@ public enum LineJoin {
     
     public var CALayerString: String {
         switch self {
-        case .miter: return kCALineJoinMiter
-        case .round: return kCALineCapRound
-        case .bevel: return kCALineJoinBevel
+        case .miter: return convertFromCAShapeLayerLineJoin(CAShapeLayerLineJoin.miter)
+        case .round: return convertFromCAShapeLayerLineCap(CAShapeLayerLineCap.round)
+        case .bevel: return convertFromCAShapeLayerLineJoin(CAShapeLayerLineJoin.bevel)
         }
     }
     
@@ -37,9 +37,9 @@ public enum LineCap {
     
     public var CALayerString: String {
         switch self {
-        case .butt: return kCALineCapButt
-        case .round: return kCALineCapRound
-        case .square: return kCALineCapSquare
+        case .butt: return convertFromCAShapeLayerLineCap(CAShapeLayerLineCap.butt)
+        case .round: return convertFromCAShapeLayerLineCap(CAShapeLayerLineCap.round)
+        case .square: return convertFromCAShapeLayerLineCap(CAShapeLayerLineCap.square)
         }
     }
     
@@ -219,4 +219,14 @@ open class ChartPointsLineLayer<T: ChartPoint>: ChartPointsLayer<T> {
         
         isInTransform = false
     }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromCAShapeLayerLineJoin(_ input: CAShapeLayerLineJoin) -> String {
+	return input.rawValue
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromCAShapeLayerLineCap(_ input: CAShapeLayerLineCap) -> String {
+	return input.rawValue
 }

--- a/SwiftCharts/Layers/ChartPointsViewsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsViewsLayer.swift
@@ -182,7 +182,7 @@ open class ChartPointsViewsLayer<T: ChartPoint, U: UIView>: ChartPointsLayer<T> 
     
     open func bringToFront() {
         for (view, _) in viewsWithChartPoints {
-            view.superview?.bringSubview(toFront: view)
+            view.superview?.bringSubviewToFront(view)
         }
     }
 }

--- a/SwiftCharts/String.swift
+++ b/SwiftCharts/String.swift
@@ -27,7 +27,7 @@ extension String {
 
     func size(_ font: UIFont) -> CGSize {
         #if swift(>=4)
-        return NSAttributedString(string: self, attributes: [NSAttributedStringKey.font: font]).size()
+        return NSAttributedString(string: self, attributes: [NSAttributedString.Key.font: font]).size()
         #else
         return NSAttributedString(string: self, attributes: [NSFontAttributeName: font]).size()
         #endif

--- a/SwiftCharts/Views/ChartAreasView.swift
+++ b/SwiftCharts/Views/ChartAreasView.swift
@@ -99,7 +99,7 @@ open class ChartAreasView: UIView {
             revealAnimation.duration = CFTimeInterval(animDuration)
             
             revealAnimation.isRemovedOnCompletion = false
-            revealAnimation.fillMode = kCAFillModeForwards
+            revealAnimation.fillMode = CAMediaTimingFillMode.forwards
             
             revealAnimation.beginTime = CACurrentMediaTime() + CFTimeInterval(animDelay)
             layer.mask?.add(revealAnimation, forKey: "revealAnimation")

--- a/SwiftCharts/Views/ChartLinesView.swift
+++ b/SwiftCharts/Views/ChartLinesView.swift
@@ -60,8 +60,8 @@ open class ChartLinesView: UIView {
 
     open func generateLayer(path: UIBezierPath) -> CAShapeLayer {
         let lineLayer = CAShapeLayer()
-        lineLayer.lineJoin = lineJoin.CALayerString
-        lineLayer.lineCap = lineCap.CALayerString
+        lineLayer.lineJoin = convertToCAShapeLayerLineJoin(lineJoin.CALayerString)
+        lineLayer.lineCap = convertToCAShapeLayerLineCap(lineCap.CALayerString)
         lineLayer.fillColor = UIColor.clear.cgColor
         lineLayer.lineWidth = lineWidth
         lineLayer.strokeColor = lineColors.first?.cgColor ?? UIColor.white.cgColor
@@ -75,12 +75,12 @@ open class ChartLinesView: UIView {
             lineLayer.strokeEnd = 0.0
             let pathAnimation = CABasicAnimation(keyPath: "strokeEnd")
             pathAnimation.duration = CFTimeInterval(animDuration)
-            pathAnimation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+            pathAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
             pathAnimation.fromValue = NSNumber(value: 0 as Float)
             pathAnimation.toValue = NSNumber(value: 1 as Float)
             pathAnimation.autoreverses = false
             pathAnimation.isRemovedOnCompletion = false
-            pathAnimation.fillMode = kCAFillModeForwards
+            pathAnimation.fillMode = CAMediaTimingFillMode.forwards
 
             pathAnimation.beginTime = CACurrentMediaTime() + CFTimeInterval(animDelay)
             lineLayer.add(pathAnimation, forKey: "strokeEndAnimation")
@@ -110,3 +110,13 @@ open class ChartLinesView: UIView {
         }
     }
  }
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToCAShapeLayerLineJoin(_ input: String) -> CAShapeLayerLineJoin {
+	return CAShapeLayerLineJoin(rawValue: input)
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToCAShapeLayerLineCap(_ input: String) -> CAShapeLayerLineCap {
+	return CAShapeLayerLineCap(rawValue: input)
+}

--- a/SwiftCharts/Views/ChartPointEllipseView.swift
+++ b/SwiftCharts/Views/ChartPointEllipseView.swift
@@ -44,7 +44,7 @@ open class ChartPointEllipseView: UIView {
                 alpha = 0
             }
             
-            UIView.animate(withDuration: TimeInterval(animDuration), delay: TimeInterval(animDelay), usingSpringWithDamping: animDamping, initialSpringVelocity: animInitSpringVelocity, options: UIViewAnimationOptions(), animations: {
+            UIView.animate(withDuration: TimeInterval(animDuration), delay: TimeInterval(animDelay), usingSpringWithDamping: animDamping, initialSpringVelocity: animInitSpringVelocity, options: UIView.AnimationOptions(), animations: {
                 if self.animateSize {
                     self.transform = CGAffineTransform(scaleX: 1, y: 1)
                 }

--- a/SwiftCharts/Views/ChartPointViewBarGreyOut.swift
+++ b/SwiftCharts/Views/ChartPointViewBarGreyOut.swift
@@ -35,7 +35,7 @@ open class ChartPointViewBarGreyOut: ChartPointViewBar {
     override open func didMoveToSuperview() {
         super.didMoveToSuperview()
         
-        UIView.animate(withDuration: CFTimeInterval(greyOutSettings.greyOutAnimDuration), delay: CFTimeInterval(greyOutSettings.greyOutDelay), options: UIViewAnimationOptions.curveEaseOut, animations: {
+        UIView.animate(withDuration: CFTimeInterval(greyOutSettings.greyOutAnimDuration), delay: CFTimeInterval(greyOutSettings.greyOutDelay), options: UIView.AnimationOptions.curveEaseOut, animations: {
             self.backgroundColor = UIColor.gray
         }, completion: nil)
     }

--- a/SwiftCharts/Views/ChartViewAnimators.swift
+++ b/SwiftCharts/Views/ChartViewAnimators.swift
@@ -88,7 +88,7 @@ open class ChartViewAnimators {
     }
     
     fileprivate func animate(_ settings: ChartViewAnimatorsSettings, animations: @escaping () -> Void, onFinish: @escaping () -> Void) {
-        UIView.animate(withDuration: TimeInterval(settings.animDuration), delay: TimeInterval(settings.animDelay), usingSpringWithDamping: settings.animDamping, initialSpringVelocity: settings.animInitSpringVelocity, options: UIViewAnimationOptions(), animations: {
+        UIView.animate(withDuration: TimeInterval(settings.animDuration), delay: TimeInterval(settings.animDelay), usingSpringWithDamping: settings.animDamping, initialSpringVelocity: settings.animInitSpringVelocity, options: UIView.AnimationOptions(), animations: {
             animations()
             }, completion: {finished in
                 if finished {


### PR DESCRIPTION
# Why
* So that SwiftCharts can compile under Swift 4.2 (See #370 )

# How
* Run the Swift syntax conversion on master

# Side effects
* No tests are available to make sure nothing broke