### PR TITLE
build swiftcharts headers first

### DIFF
--- a/SwiftCharts.xcodeproj/project.pbxproj
+++ b/SwiftCharts.xcodeproj/project.pbxproj
@@ -949,9 +949,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 06405DBC1B8AA74700A689FF /* Build configuration list for PBXNativeTarget "SwiftCharts" */;
 			buildPhases = (
+				06405DA31B8AA74700A689FF /* Headers */,
 				06405DA11B8AA74700A689FF /* Sources */,
 				06405DA21B8AA74700A689FF /* Frameworks */,
-				06405DA31B8AA74700A689FF /* Headers */,
 				06405DA41B8AA74700A689FF /* Resources */,
 			);
 			buildRules = (

--- a/SwiftCharts.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
+++ b/SwiftCharts.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:SwiftCharts.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:SwiftCharts.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SwiftCharts.xcodeproj/xcshareddata/xcschemes/SwiftCharts tvOS.xcscheme
+++ b/SwiftCharts.xcodeproj/xcshareddata/xcschemes/SwiftCharts tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:SwiftCharts.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SwiftCharts.xcodeproj/xcshareddata/xcschemes/SwiftCharts.xcscheme
+++ b/SwiftCharts.xcodeproj/xcshareddata/xcschemes/SwiftCharts.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06405DA51B8AA74700A689FF"
+            BuildableName = "SwiftCharts.framework"
+            BlueprintName = "SwiftCharts"
+            ReferencedContainer = "container:SwiftCharts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "06405DA51B8AA74700A689FF"
-            BuildableName = "SwiftCharts.framework"
-            BlueprintName = "SwiftCharts"
-            ReferencedContainer = "container:SwiftCharts.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:SwiftCharts.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Context For this change:
When LoopKit/Loop is built as workspace ( see https://github.com/LoopKit/LoopWorkspace) with xcode 13.3+build order set to "automatic" rather than "manual" we get a cycle problem related to swiftcharts (which is a dependency to Loop). This fixes that problem by building the headers first

Let me know if I need to undo the xcscheme changes before merging. (Those edits were automatically created by xcode)

Link to discussion of this issue: https://loop.zulipchat.com/#narrow/stream/209438-Build-Issues/topic/Dev.20Workspace.20Build.20Issue.20with.20new.20SPM.20package/near/275352863